### PR TITLE
Version 0.10.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,22 @@
+0.10.4 (01/08/24)
+
+This is a small update to update docs and make style changes to the library.
+
+Many aliased (duplicate) functions have been removed from the following classes:
+* EVNAlpha
+* EVNMotor
+* EVNDrivebase
+* EVNIMUSensor
+* EVNColourSensor
+* EVNServo
+* EVNContinuousServo
+
+More alias functions may be removed in future updates, and some may remain but this will be an exception, not the norm moving forward.
+
+-- Bugfixes --
+
+EVNMotor: stop() was declared but undefined. It has now been defined, and replaces brake() as the braking function. So do not call brake() in your code.
+
 0.10.3 (28/07/24)
 
 -- Features --

--- a/docs/actuators/evncontinuousservo.rst
+++ b/docs/actuators/evncontinuousservo.rst
@@ -73,19 +73,18 @@ Functions
 Using Continuous Servos
 """"""""""""""""""""""""
 
-.. function::   void write(float duty_cycle)
-                void writeDutyCycle(float duty_cycle)
+.. function::   void write(float duty_cycle_pct)
 
-    Runs continuous rotation servo at given duty cycle (-100% - 100%)
+    Runs continuous rotation servo at given duty cycle in %(-100 to 100)
 
-    :param duty_cycle: Duty cycle to run servo at (-1 to 1).
+    :param duty_cycle_pct: Duty cycle to run servo at (Number from -100 to 100).
 
     .. code-block:: cpp
 
         //write servo to run at 80% duty cycle
-        cservo.write(0.8);
+        cservo.write(80);
 
-.. function:: void writeMicroseconds(float pulse_us)
+.. function:: void writeMicroseconds(uint16_t pulse_us)
 
     Sends pulse of given length to continuous rotation servo
 

--- a/docs/actuators/evncontinuousservo.rst
+++ b/docs/actuators/evncontinuousservo.rst
@@ -47,9 +47,9 @@ Constructor
     
     .. code-block:: cpp
 
-        EVNContinuousServo servo(1);
+        EVNContinuousServo cservo(1);
 
-        EVNContinuousServo servo2(2, DIRECT, 600, 2400);
+        EVNContinuousServo cservo(2, DIRECT, 600, 2400);
 
 Functions
 ---------
@@ -60,11 +60,11 @@ Functions
 
     .. code-block:: cpp
 
-        EVNContinuousServo servo(1);
+        EVNContinuousServo cservo(1);
 
         void setup1()   //call on setup1() for best performance!
         {
-            servo.begin();
+            cservo.begin();
         }
 
 .. note::
@@ -81,6 +81,7 @@ Using Continuous Servos
     :param duty_cycle: Duty cycle to run servo at (-1 to 1).
 
     .. code-block:: cpp
+
         //write servo to run at 80% duty cycle
         cservo.write(0.8);
 
@@ -91,5 +92,6 @@ Using Continuous Servos
     :param pulse_us: Pulse time to transmit to continuous rotation servo (in microseconds) from 200us to 2800us
 
     .. code-block:: cpp
+
         //write 1500us pulse to continuous rotation servo
         cservo.writeMicroseconds(1500);

--- a/docs/actuators/evncontinuousservo.rst
+++ b/docs/actuators/evncontinuousservo.rst
@@ -45,13 +45,11 @@ Constructor
     :param min_pulse_us: Minimum pulse time sent to the servo motor (in microseconds). Defaults to 600
     :param max_pulse_us: Maximum pulse time sent to the servo motor (in microseconds). Defaults to 2400
     
-Example Usage:
+    .. code-block:: cpp
 
-.. code-block:: cpp
+        EVNContinuousServo servo(1);
 
-    EVNContinuousServo servo(1);
-
-    EVNContinuousServo servo2(2, DIRECT, 600, 2400);
+        EVNContinuousServo servo2(2, DIRECT, 600, 2400);
 
 Functions
 ---------
@@ -60,19 +58,17 @@ Functions
 
     Initializes continuous rotation servo object. Call this function before calling the other EVNContinuousServo functions.
 
+    .. code-block:: cpp
+
+        EVNContinuousServo servo(1);
+
+        void setup1()   //call on setup1() for best performance!
+        {
+            servo.begin();
+        }
+
 .. note::
     For best performance, run this on the 2nd core using ``void setup1()``
-
-Example Program:
-
-.. code-block:: cpp
-
-    EVNContinuousServo servo(1);
-
-    void setup1()   //call on setup1() for best performance!
-    {
-        servo.begin();
-    }
 
 Using Continuous Servos
 """"""""""""""""""""""""
@@ -84,9 +80,16 @@ Using Continuous Servos
 
     :param duty_cycle: Duty cycle to run servo at (-1 to 1).
 
+    .. code-block:: cpp
+        //write servo to run at 80% duty cycle
+        cservo.write(0.8);
 
 .. function:: void writeMicroseconds(float pulse_us)
 
     Sends pulse of given length to continuous rotation servo
 
     :param pulse_us: Pulse time to transmit to continuous rotation servo (in microseconds) from 200us to 2800us
+
+    .. code-block:: cpp
+        //write 1500us pulse to continuous rotation servo
+        cservo.writeMicroseconds(1500);

--- a/docs/actuators/evndrivebase.rst
+++ b/docs/actuators/evndrivebase.rst
@@ -12,43 +12,44 @@ Constructor
 
     :param motor_left: Pointer to ``EVNMotor`` object for left motor
 
-    :param motor_right: Pointer to ``EVNMotor`` object for right motor;
+    :param motor_right: Pointer to ``EVNMotor`` object for right motor
 
-Example Usage:
+    .. code-block:: cpp
 
-.. code-block:: cpp
+        EVNMotor left_motor(1, EV3_MED);
+        EVNMotor right_motor(2, EV3_MED, REVERSE);
 
-    EVNMotor left_motor(1, EV3_MED);
-    EVNMotor right_motor(2, EV3_MED, REVERSE);
-    //wheel diameter - 62mm, axle track - 178mm
-    EVNDrivebase db(62, 178, &left_motor, &right_motor);
+        //wheel diameter - 62.4mm, axle track - 178mm
+        EVNDrivebase db(62.4, 178, &left_motor, &right_motor);
 
+.. note::
+
+    For those new to C, pointers can be quite confusing! Think of ``&`` as a means for you to provide a link to an object. 
+    Here, we pass a link to ``EVNMotor`` objects to our ``EVNDrivebase`` object, so that it can control the ``EVNMotor`` objects just like the user normally can.
 
 Functions
 ---------
 
 .. function:: void begin();
 
-    Initializes drivebase object. Call this function after calling begin() on the EVNMotor objects, but before calling any other EVNDrivebase functions.
+    Initializes drivebase object. Call this function after calling ``begin()`` on the EVNMotor objects (these still need to be called!), but before calling any other ``EVNDrivebase`` functions.
+
+    .. code-block:: cpp
+
+        EVNMotor left_motor(1, EV3_MED);
+        EVNMotor right_motor(2, EV3_MED, REVERSE);
+        EVNDrivebase db(62, 178, &left_motor, &right_motor);
+
+        void setup1()
+        {
+            left_motor.begin();
+            right_motor.begin();
+            db.begin();
+        }
 
 .. note::
     This command should be run on the 2nd core using ``void setup1()``. 
     However, you can still call the movement functions in ``void loop()`` like a normal program.
-
-Example Program:
-
-.. code-block:: cpp
-
-    EVNMotor left_motor(1, EV3_MED);
-    EVNMotor right_motor(2, EV3_MED, REVERSE);
-    EVNDrivebase db(62, 178, &left_motor, &right_motor);
-
-    void setup1()
-    {
-        left_motor.begin();
-        right_motor.begin();
-        db.begin();
-    }
 
 Measurements
 """"""""""""
@@ -57,30 +58,59 @@ Measurements
 
     :returns: Distance travelled by drivebase (in mm)
 
+    .. code-block:: cpp
+
+        float distance = db.getDistance();
+
 .. function:: float getAngle()
 
     :returns: Angle turned by drivebase (in deg)
+    
+    .. code-block:: cpp
+
+        float angle = db.getAngle();
 
 .. function:: float getHeading()
 
-    :returns: Drivebase heading (ranges from 0 - 360deg)
+    :returns: Drivebase heading (ranging from 0-360 degrees)
+
+    .. code-block:: cpp
+
+        float heading = db.getHeading();
 
 .. function:: float getX()
 
     :returns: X coordinate of drivebase from origin (origin is the drivebase's position on startup)
 
+    .. code-block:: cpp
+
+        float x = db.getX();
+
 .. function:: float getY()
 
     :returns: Y coordinate of drivebase from origin (origin is the drivebase's position on startup)
 
+    .. code-block:: cpp
+
+        float y = db.getY();
+
 .. function:: void resetXY();
 
-    Sets drivebase's position to be Origin (0, 0).
+    Sets drivebase's current position to be the origin (0, 0).
+
+    .. code-block:: cpp
+        
+        db.resetXY();
+        //afterwards, getX() and getY() will return 0
 
 .. function:: float getDistanceToPoint(float x, float y);
 
     :returns: Euclidean distance between drivebase's XY position and target XY point
 
+    .. code-block:: cpp
+
+        //if drivebase is at origin, the distance to point will be 4
+        float distance_to_point = db.getDistanceToPoint(3,2);
 
 Move Forever
 """"""""""""
@@ -94,6 +124,11 @@ Move Forever
 
     :param turn_rate: turning rate of drivebase (in deg/s)
 
+    .. code-block:: cpp
+        
+        //drive at a velocity of 50mm/s and turning rate of 5deg/s
+        db.drive(50, 5);
+
 .. function:: void driveRadius(float speed, float radius);
 
     Runs drivebase at the given speed and radius of turning until a new command is called
@@ -101,6 +136,11 @@ Move Forever
     :param speed: velocity of drivebase (in mm/s)
 
     :param radius: turning radius of drivebase (in mm)
+
+    .. code-block:: cpp
+        
+        //drive at a velocity of 50mm/s and move in an arc of radius 50mm
+        db.driveRadius(50, 50);
 
 
 Move by a Fixed Amount
@@ -122,6 +162,11 @@ Move by a Fixed Amount
 
     :param wait: Block function from returning until command is finished
 
+    .. code-block:: cpp
+        
+        //move in a straight line at a velocity of 50mm/s for a distance of 50mm
+        db.straight(50, 50);
+
 .. function::   void curve(float speed, float radius, float angle, uint8_t stop_action = STOP_BRAKE, bool wait = true);
                 void curveRadius(float speed, float radius, float angle, uint8_t stop_action = STOP_BRAKE, bool wait = true);
 
@@ -141,6 +186,11 @@ Move by a Fixed Amount
 
     :param wait: Block function from returning until command is finished
 
+    .. code-block:: cpp
+        
+        //drive at a velocity of 50mm/s in an arc of radius 50mm until the drivebase has rotated by 90 degrees
+        db.curve(50, 50, 90, STOP_BRAKE);
+
 .. function:: void curveTurnRate(float speed, float turn_rate, float angle, uint8_t stop_action = STOP_BRAKE, bool wait = true);
 
     Runs drivebase at given speed and turn rate until its heading has shifted by the given angle, then runs specified stop action
@@ -159,6 +209,11 @@ Move by a Fixed Amount
 
     :param wait: Block function from returning until command is finished
 
+    .. code-block:: cpp
+        
+        //drive at a velocity of 50mm/s at a turning rate of 5deg/s until the drivebase has rotated by 90 degrees
+        db.curveTurnRate(50, 5, 90, STOP_BRAKE);
+
 .. function::   void turn(float turn_rate, float degrees, uint8_t stop_action = STOP_BRAKE, bool wait = true);
                 void turnDegrees(float turn_rate, float degrees, uint8_t stop_action = STOP_BRAKE, bool wait = true);
 
@@ -176,6 +231,11 @@ Move by a Fixed Amount
 
     :param wait: Block function from returning until command is finished
 
+    .. code-block:: cpp
+        
+        //rotate at a rate of 5deg/s until the drivebase has rotated by 90 degrees
+        db.turn(5, 90, STOP_BRAKE);
+
 .. function:: void turnHeading(float turn_rate, float heading, uint8_t stop_action = STOP_BRAKE, bool wait = true);
 
     Rotate drivebase on the spot to the given heading, then performs given stop action
@@ -192,9 +252,19 @@ Move by a Fixed Amount
 
     :param wait: Block function from returning until command is finished
 
+    .. code-block:: cpp
+        
+        //rotate at a rate of 5deg/s (or -5deg/s) until the drivebase has a heading of 90degrees
+        db.turnHeading(5, 90, STOP_BRAKE);    
+
 .. function:: bool completed();
 
     :returns: Boolean indicating whether the drivebase's command has reached completion
+
+    .. code-block:: cpp
+
+        //wait until drivebase has completed its command
+        while (!db.completed());
 
 Move to Point
 """"""""""""""""
@@ -218,7 +288,12 @@ Move to Point
 
     :param wait: Block function from returning until command is finished
 
-.. note:: This feature is experimental! Its behaviour may be changed in future versions.
+    .. code-block:: cpp
+        
+        //drive to point (60, 60) at a velocity of 100mm/s and turning rate of 50deg/s
+        db.driveToXY(100, 50, 60, 60, STOP_BRAKE);
+
+.. note:: This feature is experimental! And also, it's pretty much a party trick. Its behaviour may be changed in future versions.
 
 Stopping
 """"""""
@@ -228,14 +303,26 @@ Stopping
 
     Brakes both drivebase motors (slow decay)
 
+    .. code-block:: cpp
+        
+        db.stop();
+        db.brake(); //same effect
+
 .. function:: void coast();
     
     Coast both drivebase motors (fast decay)
-
+    
+    .. code-block:: cpp
+    
+        db.coast();
 
 .. function:: void hold();
     
     Hold drivebase motors in their current positions
+
+    .. code-block:: cpp
+    
+        db.hold();
 
 Control Settings
 """"""""""""""""
@@ -254,6 +341,10 @@ To view the default PID and accel/decel values, look at ``src\evn_motor_defs.h``
     :param ki: Integral gain
     :param kd: Derivative gain
 
+    .. code-block:: cpp
+    
+        db.setSpeedPID(0.4, 0.04, 2);
+
 .. function:: void setTurnRatePID(float kp, float ki, float kd);
 
     Sets PID gain values for the turn rate controller (controls rate of turning of drivebase).
@@ -268,18 +359,38 @@ To view the default PID and accel/decel values, look at ``src\evn_motor_defs.h``
     :param ki: Integral gain
     :param kd: Derivative gain
 
+    .. code-block:: cpp
+    
+        db.setTurnRatePID(0.4, 0.04, 2);
+
 .. function:: void setSpeedAccel(float speed_accel);
 
     Sets speed acceleration value for drivebase (in mm/s^2).
 
+    .. code-block:: cpp
+    
+        db.setSpeedAccel(500);
+
 .. function:: void setSpeedDecel(float speed_decel);
 
-    Sets speed acceleration value for drivebase (in mm/s^2).
+    Sets speed deceleration value for drivebase (in mm/s^2).
+
+    .. code-block:: cpp
+    
+        db.setSpeedDecel(500);
 
 .. function:: void setTurnRateAccel(float turn_rate_accel);
 
-    Sets turn rate deceleration value for drivebase (in deg/s^2).
+    Sets turn rate acceleration value for drivebase (in deg/s^2).
+
+    .. code-block:: cpp
+    
+        db.setTurnRateAccel(500);
 
 .. function:: void setTurnRateDecel(float turn_rate_decel);
 
     Sets turn rate deceleration value for drivebase (in deg/s^2).
+
+    .. code-block:: cpp
+    
+        db.setTurnRateDecel(500);

--- a/docs/actuators/evndrivebase.rst
+++ b/docs/actuators/evndrivebase.rst
@@ -299,18 +299,16 @@ Stopping
 """"""""
 
 .. function::   void stop();
-                void brake();
 
     Brakes both drivebase motors (slow decay)
 
     .. code-block:: cpp
         
         db.stop();
-        db.brake(); //same effect
 
 .. function:: void coast();
     
-    Coast both drivebase motors (fast decay)
+    Coasts both drivebase motors to a stop (fast decay)
     
     .. code-block:: cpp
     

--- a/docs/actuators/evnmotor.rst
+++ b/docs/actuators/evnmotor.rst
@@ -92,8 +92,7 @@ Measurements
         motor.resetPosition();
         //afterwards, getPosition will return 0
 
-.. function::   float getDPS()
-                float getSpeed()
+.. function::   float getSpeed()
 
     :returns: Angular velocity of motor, in DPS (degrees per second)
 
@@ -123,8 +122,7 @@ Run Forever
         //run motor at 80% duty cycle
         motor.runPWM(80);
 
-.. function::   void runDPS(float dps)
-                void runSpeed(float dps)
+.. function::   void runSpeed(float dps)
 
     Runs the motor at the given angular velocity until a new command is called. Motor will attempt to maintain constant speed despite varying load torque.
 

--- a/docs/actuators/evnmotor.rst
+++ b/docs/actuators/evnmotor.rst
@@ -37,14 +37,12 @@ Constructor
 
     :param enc_dir: When set to ``REVERSE``, flips encoder pins **only**. Not necessary for LEGO motors, but useful for non-LEGO gearmotors when the encoder input and motor output increment in opposing directions. Defaults to ``DIRECT``
 
-Example Usage:
+    .. code-block:: cpp
 
-.. code-block:: cpp
-
-    EVNMotor motor1(1, EV3_MED);
-    EVNMotor motor2(2, EV3_LARGE);
-    EVNMotor motor3(3, NXT_LARGE, REVERSE);
-    EVNMotor motor4(4, CUSTOM_MOTOR, DIRECT, REVERSE);
+        EVNMotor motor1(1, EV3_MED);
+        EVNMotor motor2(2, EV3_LARGE);
+        EVNMotor motor3(3, NXT_LARGE, REVERSE);
+        EVNMotor motor4(4, CUSTOM_MOTOR, DIRECT, REVERSE);
 
 Functions
 ---------
@@ -53,20 +51,18 @@ Functions
 
     Initializes motor object. Call this function before calling the other EVNMotor functions.
 
+    .. code-block:: cpp
+
+        EVNMotor motor(1, EV3_MED);
+
+        void setup1()   //call on setup1(), not setup()!
+        {
+            motor.begin();
+        }
+
 .. note::
     This command should be run on the 2nd core using ``void setup1()``. 
     However, you can still call the movement functions in ``void loop()`` like a normal program.
-
-Example Program:
-
-.. code-block:: cpp
-
-    EVNMotor motor(1, EV3_MED);
-
-    void setup1()   //call on setup1(), not setup()!
-    {
-        motor.begin();
-    }
 
 Measurements
 """"""""""""
@@ -75,32 +71,43 @@ Measurements
 
     :returns: Angular displacement of motor from its starting position, in degrees
 
+    .. code-block:: cpp
+
+        float pos = motor.getPosition();
+
 .. function:: float getHeading()
 
     :returns: Motor position converted to range from 0-360 degrees
 
+    .. code-block:: cpp
+
+        float pos = motor.getHeading(); //ranges from 0 to 360
+
 .. function:: void resetPosition()
 
     Reset starting position to motor's starting position.
+
+    .. code-block:: cpp
+
+        motor.resetPosition();
+        //afterwards, getPosition will return 0
 
 .. function::   float getDPS()
                 float getSpeed()
 
     :returns: Angular velocity of motor, in DPS (degrees per second)
 
+    .. code-block:: cpp
+
+        float speed = motor.getSpeed();
+
 .. function:: bool stalled()
 
     :returns: Boolean indicating when motor is stalled (unable to reach target velocity)
 
-Example Usage:
+    .. code-block:: cpp
 
-.. code-block:: cpp
-
-    float position = motor.getPosition();
-    float heading = motor.getHeading();
-    float speed = motor.getSpeed();
-    
-    motor.resetPosition();
+        bool is_motor_stalled = motor.stalled();
 
 Run Forever
 """""""""""
@@ -111,6 +118,11 @@ Run Forever
 
     :param duty_cycle: duty cycle to run the motor at (floating point number from -1 to 1)
 
+    .. code-block:: cpp
+
+        //run motor at 100% duty cycle
+        motor.runPWM(1);
+
 .. function::   void runDPS(float dps)
                 void runSpeed(float dps)
 
@@ -118,18 +130,31 @@ Run Forever
 
     :param dps: Angular velocity to run the motor at (in DPS)
 
-Example Usage:
+    .. code-block:: cpp
 
-.. code-block:: cpp
-
-    //run motor at 100% duty cycle
-    motor.runPWM(1);
-
-    //run motor at 300DPS in the negative direction
-    motor.runSpeed(-300);
+        //run motor at 300DPS in the negative direction
+        motor.runSpeed(-300);
 
 Run by a Fixed Amount
 """""""""""""""""""""
+.. function:: void runAngle(float dps, float degrees, uint8_t stop_action = STOP_BRAKE, bool wait = true)
+
+    Run motor by the given angle (relative to its starting position), then performs the given stop action.
+
+    :param dps: Angular velocity to run the motor at (in DPS)
+    :param degrees: Angular displacement which the motor has to travel (in degrees)
+    :param stop_action: Behaviour of the motor upon completing its command. Defaults to ``STOP_BRAKE``
+
+        * ``STOP_BRAKE`` -- Brake (Slow decay)
+        * ``STOP_COAST`` -- Coast (Fast decay)
+        * ``STOP_HOLD`` -- Hold position
+
+    :param wait: Block function from returning until command is finished
+
+    .. code-block:: cpp
+
+        //run motor for 360 degrees of rotation at speed 300DPS
+        motor.runAngle(300, 360, STOP_BRAKE);
 
 .. function:: void runPosition(float dps, float position, uint8_t stop_action = STOP_BRAKE, bool wait = true)
 
@@ -145,19 +170,10 @@ Run by a Fixed Amount
     
     :param wait: Block function from returning until command is finished
 
-.. function:: void runAngle(float dps, float degrees, uint8_t stop_action = STOP_BRAKE, bool wait = true)
+    .. code-block:: cpp
 
-    Run motor by the given angle (relative to its starting position), then performs the given stop action.
-
-    :param dps: Angular velocity to run the motor at (in DPS)
-    :param degrees: Angular displacement which the motor has to travel (in degrees)
-    :param stop_action: Behaviour of the motor upon completing its command. Defaults to ``STOP_BRAKE``
-
-        * ``STOP_BRAKE`` -- Brake (Slow decay)
-        * ``STOP_COAST`` -- Coast (Fast decay)
-        * ``STOP_HOLD`` -- Hold position
-
-    :param wait: Block function from returning until command is finished
+        //return motor to position 0 at speed 300DPS
+        motor.runPosition(300, 0, STOP_BRAKE);
 
 .. function:: void runHeading(float dps, float heading, uint8_t stop_action = STOP_BRAKE, bool wait = true)
 
@@ -173,6 +189,11 @@ Run by a Fixed Amount
 
     :param wait: Block function from returning until command is finished
 
+    .. code-block:: cpp
+
+        //return motor to heading 0 at speed 300DPS (i.e. position % 360 = o)
+        motor.runHeading(300, 0, STOP_BRAKE);
+
 .. function:: void runTime(float dps, uint32_t time_ms, uint8_t stop_action = STOP_BRAKE, bool wait = true)
 
     Run motor for the given amount of time, then performs the given stop action.
@@ -187,29 +208,19 @@ Run by a Fixed Amount
 
     :param wait: Block function from returning until command is finished
 
+    .. code-block:: cpp
+
+        //run motor for 3 seconds at speed 300DPS
+        motor.runTime(300, 3000, STOP_BRAKE);
+
 .. function:: bool completed()
 
     :returns: Boolean indicating whether the motor has hit its target position / completed running for the set amount of time
 
-Example Usage:
+    .. code-block:: cpp
 
-.. code-block:: cpp
-
-    //run motor to a position of 180 degrees
-    motor.runPosition(120, 180);
-
-    //run motor at 120DPS in the negative direction for 1 second (1000ms)
-    motor.runTime(-120, 1000, STOP_COAST);
-
-    //run motor1 180 degrees in the negative direction from its current position
-    motor1.runAngle(120, -180, STOP_HOLD, false);
-
-    //at the same time, run motor2 to a heading of 75 degrees
-    motor2.runHeading(120, 75, STOP_HOLD);
-
-    //ensure that motor1 has completed before proceeding
-    while (!motor1.completed());
-
+        //ensure that motor has completed command before proceeding
+        while (!motor.completed());
 
 Stopping
 """""""""
@@ -219,22 +230,26 @@ Stopping
 
     Brakes the motor (slow decay).
 
+    .. code-block:: cpp
+        
+        motor.stop();
+        motor.brake(); //same effect
+
 .. function:: void coast()
 
     Coasts the motor (fast decay). Compared to `brake()`, motor comes to a stop more slowly.
+
+    .. code-block:: cpp
+        
+        motor.coast();
 
 .. function:: void hold()
 
     Hold the motor in its current position. Stops the motor shaft from moving freely.
 
-Example Usage:
-
-.. code-block:: cpp
-
-    motor.stop();
-    motor.brake();
-    motor.coast();
-    motor.hold();
+    .. code-block:: cpp
+        
+        motor.hold();
 
 Control Settings
 """"""""""""""""

--- a/docs/actuators/evnmotor.rst
+++ b/docs/actuators/evnmotor.rst
@@ -112,16 +112,16 @@ Measurements
 Run Forever
 """""""""""
 
-.. function:: void runPWM(float duty_cycle)
+.. function:: void runPWM(float duty_cycle_pct)
 
-    Runs the motor at the given duty cycle using PWM until a new command is called. Motor speed will vary with load torque applied.
+    Runs the motor at the given duty cycle (in %) using PWM until a new command is called. Motor speed will vary with load torque applied.
 
-    :param duty_cycle: duty cycle to run the motor at (floating point number from -1 to 1)
+    :param duty_cycle_pct: duty cycle to run the motor at in % (number from -100 to 100)
 
     .. code-block:: cpp
 
-        //run motor at 100% duty cycle
-        motor.runPWM(1);
+        //run motor at 80% duty cycle
+        motor.runPWM(80);
 
 .. function::   void runDPS(float dps)
                 void runSpeed(float dps)

--- a/docs/actuators/evnmotor.rst
+++ b/docs/actuators/evnmotor.rst
@@ -225,19 +225,17 @@ Run by a Fixed Amount
 Stopping
 """""""""
 
-.. function::   void stop()
-                void brake()
+.. function::    void stop()
 
     Brakes the motor (slow decay).
 
     .. code-block:: cpp
         
         motor.stop();
-        motor.brake(); //same effect
 
 .. function:: void coast()
 
-    Coasts the motor (fast decay). Compared to `brake()`, motor comes to a stop more slowly.
+    Coasts the motor (fast decay). Compared to `stop()`, motor comes to a stop more slowly.
 
     .. code-block:: cpp
         

--- a/docs/actuators/evnservo.rst
+++ b/docs/actuators/evnservo.rst
@@ -60,19 +60,17 @@ Functions
 
     Initializes servo object. Call this function before calling the other EVNServo functions.
 
+    .. code-block:: cpp
+        
+        EVNServo servo(1);
+
+        void setup1()   //call on setup1() for best performance!
+        {
+            servo.begin();
+        }
+
 .. note::
     For best performance, run this on the 2nd core using ``void setup1()``
-
-Example Program:
-
-.. code-block:: cpp
-
-    EVNServo servo(1);
-
-    void setup1()   //call on setup1() for best performance!
-    {
-        servo.begin();
-    }
 
 Using Fixed Servos
 """"""""""""""""""
@@ -81,9 +79,15 @@ Using Fixed Servos
 
     :returns: Maximum angular rotation of servo shaft (in degrees per second).
 
+    .. code-block:: cpp
+        float max_dps = servo.getMaxDPS();
+
 .. function:: uint16_t getRange()
 
     :returns: Angular range of servo (in degrees).
+
+    .. code-block:: cpp
+        int range = servo.getRange();
 
 .. function::   void write(float position, float wait_time_ms, float dps)
                 void writePosition(float position, float wait_time_ms, float dps)
@@ -93,7 +97,10 @@ Using Fixed Servos
     :param position: Position to run servo shaft to (in degrees)
     :param wait_time_ms: Time to wait before continuing the program (in milliseconds). Same effect as ``delay()``, but terminates when servos are disabled.
     :param dps: Speed to run servo at (in degrees per second), from 0 to **max_range**. When dps is 0, servo runs at max speed. Defaults to 0.
-
+    
+    .. code-block:: cpp
+        //write servo to run to 180 degrees at a speed of 30DPS, and wait 6 seconds
+        servo.write(180, 6000, 30);
 
 .. function:: void writeMicroseconds(float pulse_us, float wait_time_ms)
 
@@ -101,3 +108,7 @@ Using Fixed Servos
 
     :param pulse_us: Pulse time to transmit to servo (in microseconds) from 200us to 2800us
     :param wait_time_ms: Time to wait before continuing the program (in milliseconds). Same effect as ``delay()``, but terminates when servos are disabled.
+
+    .. code-block:: cpp
+        //write 1500us pulse to servo, and wait 3 seconds
+        servo.writeMicroseconds(1500, 3000);

--- a/docs/actuators/evnservo.rst
+++ b/docs/actuators/evnservo.rst
@@ -89,8 +89,7 @@ Using Fixed Servos
     .. code-block:: cpp
         int range = servo.getRange();
 
-.. function::   void write(float position, float wait_time_ms, float dps)
-                void writePosition(float position, float wait_time_ms, float dps)
+.. function::   void write(float position, uint16_t wait_time_ms, float dps)
 
     Rotate motor shaft to given angular position.
 
@@ -102,7 +101,7 @@ Using Fixed Servos
         //write servo to run to 180 degrees at a speed of 30DPS, and wait 6 seconds
         servo.write(180, 6000, 30);
 
-.. function:: void writeMicroseconds(float pulse_us, float wait_time_ms)
+.. function:: void writeMicroseconds(uint16_t pulse_us, uint16_t wait_time_ms)
 
     Sends pulse of given length to servo.
 

--- a/docs/board/evnalpha.rst
+++ b/docs/board/evnalpha.rst
@@ -111,7 +111,7 @@ These functions will be used mainly if you are trying to operate third-party I2C
 
     .. code-block:: cpp
 
-        int port = board.getPort();        //returns 1 on startup
+        int port = board.getPort(); //returns 1 on startup
     
 .. function:: uint8_t getWirePort()
 
@@ -119,7 +119,7 @@ These functions will be used mainly if you are trying to operate third-party I2C
 
     .. code-block:: cpp
         
-        int wport = board.getWirePort();        //returns 1 on startup
+        int wport = board.getWirePort();    //returns 1 on startup
 
 .. function:: uint8_t getWire1Port()
 
@@ -127,7 +127,7 @@ These functions will be used mainly if you are trying to operate third-party I2C
 
     .. code-block:: cpp
         
-        int w1port = board.getWire1Port();        //returns 9 on startup
+        int w1port = board.getWire1Port();  //returns 9 on startup
 
 .. function:: void printPorts()
 

--- a/docs/board/evnalpha.rst
+++ b/docs/board/evnalpha.rst
@@ -1,7 +1,7 @@
 ``EVNAlpha``
 ========================================
 
-EVNAlpha is a class used to interface with the onboard hardware on EVN Alpha.
+EVNAlpha is a class used to interface with the onboard hardware on EVN Alpha:
 
 * Button
 * LED
@@ -15,7 +15,7 @@ EVNAlpha uses **hardware interrupts** for the onboard button to act as an toggle
 
 By default, the button output is also linked to 2 other functions. Both can disabled by the user if needed:
 
-* Motor Operation: the button acts as a motor disable switch, so that users can pause their robot before uploading
+* Motor Operation: the button can act as a motor disable switch, so that users can pause their robot before uploading
 * LED: the LED acts as an indicator for the button output
 
 EVN Alpha has 2 TCA9548A I2C multiplexers, 1 on each I2C bus. This allows users to connect multiple I2C devices with the same I2C address without worrying about address clashing. However, users must set the port (1-16) for a given peripheral before communicating with it. EVNAlpha includes functions for port selection and de-selection to ease this process.
@@ -42,15 +42,13 @@ EVN Alpha has 2 TCA9548A I2C multiplexers, 1 on each I2C bus. This allows users 
 
     :param i2c_freq: I2C frequency in Hz. Defaults to 400000 (400kHz).
 
-Example Usage:
+    .. code-block:: cpp
 
-.. code-block:: cpp
+        //constructor with default options
+        EVNAlpha board;
 
-    //constructor with default options
-    EVNAlpha board;
-
-    //constructor if you wish to set non-default options
-    EVNAlpha board(BUTTON_PUSHBUTTON, false, false, false, 400000);
+        //constructor if you wish to set non-default options
+        EVNAlpha board(BUTTON_PUSHBUTTON, false, false, false, 400000);
 
 Functions
 ---------
@@ -58,16 +56,14 @@ Functions
 
     Initializes on-board hardware. This function should be called at the start of ``void setup()``, before anything else.
 
-Example Program:
+    .. code-block:: cpp
 
-.. code-block:: cpp
+        EVNAlpha board;
 
-    EVNAlpha board;
-
-    void setup()
-    {
-        board.begin();
-    }
+        void setup()
+        {
+            board.begin();
+        }
 
 LED / Button
 """"""""""""
@@ -79,6 +75,10 @@ LED / Button
 
     :returns: boolean signifying button output
 
+    .. code-block:: cpp
+
+        bool button_output = board.read();
+
 .. function::   void write(bool state)
                 void ledWrite(bool state)
 
@@ -86,51 +86,66 @@ LED / Button
 
     :param state: state to write to LED
 
-Example Usage:
+    .. code-block:: cpp
 
-.. code-block:: cpp
-
-    board.read();
-    board.write(true);  //LED on
-    board.write(false); //LED off
+        board.write(true);  //LED on
+        board.write(false); //LED off
 
 I2C Port Control
 """"""""""""""""
 
+These functions will be used mainly if you are trying to operate third-party I2C devices, that aren't Standard Peripherals.
+
 .. function:: void setPort(uint8_t port)
 
-    :param port: I2C port to be enabled (1--16)
+    :param port: I2C port to be enabled (1-16)
+
+    .. code-block:: cpp
+        
+        //set I2C port 16 to be active
+        board.setPort(16);
 
 .. function:: uint8_t getPort()
 
-    :returns: last I2C port called using ``setPort()`` (1--16)
+    :returns: last I2C port called using ``setPort()`` (1-16)
 
+    .. code-block:: cpp
+
+        int port = board.getPort();        //returns 1 on startup
+    
 .. function:: uint8_t getWirePort()
 
-    :returns: last Wire I2C port called using ``setPort()`` (1--8)
+    :returns: last Wire I2C port called using ``setPort()`` (1-8)
+
+    .. code-block:: cpp
+        
+        int wport = board.getWirePort();        //returns 1 on startup
 
 .. function:: uint8_t getWire1Port()
 
-    :returns: last Wire1 I2C port called using ``setPort()`` (9--16)
+    :returns: last Wire1 I2C port called using ``setPort()`` (9-16)
+
+    .. code-block:: cpp
+        
+        int w1port = board.getWire1Port();        //returns 9 on startup
 
 .. function:: void printPorts()
 
-    Prints all I2C devices on every port using ``Serial``
+    This is an I2C port scanner function which prints all I2C devices on every port using ``Serial``
 
-Example Usage:
+    .. code-block:: cpp
+        
+        board.printPorts();
 
-.. code-block:: cpp
+    Example Serial Monitor Output:
 
-    board.getPort();        //returns 1 on startup
-    board.getWirePort();    //returns 1 on startup
-    board.getWire1Port();   //returns 9 on startup
+    .. code-block::
 
-    board.setPort(3);       //set Wire to connect to Port 3
-    board.setPort(10);      //set Wire1 to connect to Port 10
+        EVN Alpha I2C Port Scanner
+        Battery: 8.183V | Cell 1: 4.096V | Cell 2: 4.087
+        Port 16: 0x6A
 
-    board.getPort();        //returns 10
-    board.getWirePort();    //returns 3
-    board.getWire1Port();   //returns 10
+    Even though no peripherals are connected to the board, port 16 has one I2C device under address 0x6A, which is our onboard battery charger and voltage measurement device.
 
 Battery Voltage Reading
 """"""""""""""""""""""""
@@ -156,7 +171,11 @@ To add the alert to your code, add ``getBatteryVoltage()`` (or ``getCell1Voltage
     :param low_threshold_mv: Battery voltage threshold (in millivolts). When battery voltage falls below this voltage and ``flash_when_low`` is ``true``, low voltage alert is triggered. Defaults to 6900.
 
     :returns: combined voltage of both battery cells in millivolts
+    
+    .. code-block:: c++
 
+        int battery = board.getBatteryVoltage();
+        
 .. function:: int16_t getCell1Voltage(bool flash_when_low = true, uint16_t low_threshold_mv = 3450)
 
     Cell 1 refers to the cell nearer to the edge of the board.
@@ -165,6 +184,10 @@ To add the alert to your code, add ``getBatteryVoltage()`` (or ``getCell1Voltage
     :param low_threshold_mv: Cell voltage threshold (in millivolts). When this cell's voltage falls below this threshold and ``flash_when_low`` is ``true``, low battery alert is triggered. Defaults to 3450.
 
     :returns: voltage of first cell in millivolts
+
+    .. code-block:: c++
+
+        int cell1 = board.getCell1Voltage();
 
 .. function:: int16_t getCell2Voltage(bool flash_when_low = true, uint16_t low_threshold_mv = 3450)
 
@@ -175,50 +198,47 @@ To add the alert to your code, add ``getBatteryVoltage()`` (or ``getCell1Voltage
 
     :returns: voltage of second cell in millivolts
 
-Example Program:
+    .. code-block:: c++
 
-.. code-block:: cpp
-
-    EVNAlpha board;
-
-    void setup()
-    {
-        board.begin();
-
-        int batt = board.getBatteryVoltage();
-        int cell1 = board.getCell1Voltage();
         int cell2 = board.getCell2Voltage();
-    }
-
-Example Output (on Serial Monitor):
-
-.. code-block:: cpp
-
-    8392
-    4198
-    4194
 
 Set Functions
 """""""""""""
 .. function:: void setMode(uint8_t mode)
 
-    :param mode: Determines behaviour of ``buttonRead()``
+    :param mode: Determines behaviour of ``buttonRead()`` (options shown below)
     
     * ``BUTTON_TOGGLE``
     * ``BUTTON_PUSHBUTTON``
     * ``BUTTON_DISABLE``
 
+    .. code-block:: c++
+
+        board.setMode(BUTTON_TOGGLE);
+
 .. function:: void setLinkLED(bool enable)
 
     :param enable: Links LED to display ``buttonRead()`` output
+
+    .. code-block:: c++
+
+        board.setLinkLED(true);
 
 .. function:: void setLinkMovement(bool enable)
 
     :param enable: Links all motor and servo operation to ``buttonRead()`` output
 
+    .. code-block:: c++
+
+        board.setLinkMovement(true);
+
 .. function:: void setButtonInvert(bool enable)
 
     :param enable: Inverts output of ``buttonRead()``
+
+    .. code-block:: c++
+
+        board.setButtonInvert(true);
 
 Get Functions
 """"""""""""""
@@ -236,15 +256,33 @@ Get Functions
     * 1 (``BUTTON_TOGGLE``)
     * 2 (``BUTTON_PUSHBUTTON``)
 
-.. function:: bool setLinkLED()
+    .. code-block:: c++
+
+        if (board.getMode() == BUTTON_TOGGLE)
+        {
+
+        }
+
+.. function:: bool getLinkLED()
 
     :returns: Whether LED is linked to ``buttonRead()`` output
 
-.. function:: bool setLinkMovement()
+    .. code-block:: c++
+
+        bool link_led = board.getLinkLED();
+
+.. function:: bool getLinkMovement()
 
     :returns: Whether motor and servo operation is linked to ``buttonRead()`` output
 
-.. function:: bool setButtonInvert()
+    .. code-block:: c++
+
+        bool link_movement = board.getLinkLED();
+
+.. function:: bool getButtonInvert()
 
     :returns: Whether output of ``buttonRead()`` is inverted
 
+    .. code-block:: c++
+
+        bool button_invert = board.getButtonInvert();

--- a/docs/board/evnalpha.rst
+++ b/docs/board/evnalpha.rst
@@ -68,8 +68,7 @@ Functions
 LED / Button
 """"""""""""
 
-.. function::   bool read()
-                bool buttonRead()
+.. function::   bool buttonRead()
 
     Get button output (varies depending on mode parameter in class constructor)
 
@@ -77,10 +76,9 @@ LED / Button
 
     .. code-block:: cpp
 
-        bool button_output = board.read();
+        bool button_output = board.buttonRead();
 
-.. function::   void write(bool state)
-                void ledWrite(bool state)
+.. function::   void ledWrite(bool state)
 
     Set LED to turn on (``true``) or off (``false``). However, the LED state can be overridden by the battery reading functions (see below).
 
@@ -88,8 +86,8 @@ LED / Button
 
     .. code-block:: cpp
 
-        board.write(true);  //LED on
-        board.write(false); //LED off
+        board.ledWrite(true);  //LED on
+        board.ledWrite(false); //LED off
 
 I2C Port Control
 """"""""""""""""

--- a/docs/displays/evndisplay.rst
+++ b/docs/displays/evndisplay.rst
@@ -54,8 +54,6 @@ Printing Data to a Row
 """"""""""""""""""""""
 
 .. function::   void writeLabel(uint8_t row, data)
-                void writeLine(uint8_t row, data)
-                void write(uint8_t row, data)
                 void print(uint8_t row, data)
                 
 

--- a/docs/getting-started/programming.rst
+++ b/docs/getting-started/programming.rst
@@ -86,8 +86,8 @@ This is what an example sketch with 2 motors and 2 colour sensors would look lik
 
     void loop()
     {
-        int cs1_reading = cs1.read();
-        int cs2_reading = cs2.read();
+        int cs1_reading = cs1.readClear();
+        int cs2_reading = cs2.readClear();
 
         //do something with colour sensor readings here
 

--- a/docs/getting-started/standard-peripherals.rst
+++ b/docs/getting-started/standard-peripherals.rst
@@ -46,7 +46,7 @@ Standard Peripherals each come with a cable to connect to Alpha.
     * The 270 Degree Servo and Continuous Servo Peripherals come with non-removable 3-Wire cables.
 
 At one end of the cable, all the wires will be joined into one plastic connector. 
-This connector plugs into the EVN Alpha brick, and has a notch which acts as a **key** to avoid being plugged in reverse.
+With the exception of the Servo Peripherals, this connector plugs into the EVN Alpha brick, and has a notch to avoid being plugged in reverse (called a **key**).
 The wire colours are also colour-coded to match the pin layout of the ports on EVN Alpha.
 
 On the other end of the cable, each wire is separated from the others. They all need to be connected to the Peripheral, but they're not joined together
@@ -54,8 +54,20 @@ because the layout of the pins differs with each Peripheral.
 
 The library reference page for each Peripheral (linked below) contains a pin layout section to guide you on the connections.
 
-I2C Wire Colours
-"""""""""""""""""""
+The pins we used on the Alpha and Standard Peripherals are standard 2.54mm pitch pin headers, and the cables can be substituted with 2.54mm Dupont jumper wires as well! 
+Jumper cables don't have a key, so you'll need to be slightly more careful, but they will work perfectly. Likewise, our cables will function well for interfacing with non-Standard Peripherals if they also 2.54mm pitch pins.
+
+Wiring
+--------
+
+Generally speaking, all peripherals have a VCC pin and GND pin.
+
+In order to supply power to these peripherals, the GND pin on the peripheral should be connected to a GND pin on the controller (EVN Alpha) and the VCC pin on the peripheral should be connected to a voltage output on the controller (depending on the peripheral, this could be a 3.3V or 5V pin).
+
+As for the data pins, each communication protocol is wired in a different manner:
+
+I2C
+"""""
 
 .. list-table::
    :widths: 25 25 50
@@ -77,7 +89,9 @@ I2C Wire Colours
      - SDA
      - Serial Data
 
-Serial Wire Colours
+I2C is wired such that the SDA pin of the host (EVN Alpha) is connected to the SDA pin of a peripheral, and the same goes for the SCL pins.
+
+Serial Wiring
 """""""""""""""""""
 
 .. list-table::
@@ -100,7 +114,9 @@ Serial Wire Colours
      - TX
      - Receive
 
-Servo Wire Colours
+Serial UART is wired such that the Transmit (TX) pin of the peripheral connects to the Receive (RX) pin of the host, and vice versa (TX of one always connects to RX of the other).
+
+Servo Wiring
 """""""""""""""""""
 
 .. list-table::
@@ -120,8 +136,7 @@ Servo Wire Colours
      - GND
      - Ground
 
-The pins we used on the Alpha and Standard Peripherals are standard 2.54mm pitch pin headers, and the cables can be substituted with 2.54mm Dupont jumper wires as well! 
-Jumper cables don't have a key, so you'll need to be slightly more careful, but they will work perfectly. Likewise, our cables will function well for interfacing with non-Standard Peripherals, as long as they also use 2.54mm pitch pins.
+The Servo ports only have one Signal pin, so as long as the signal pins on both peripheral and host are connected, you're all good.
 
 List of Standard Peripherals
 ----------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,8 +40,8 @@ To find out more about purchasing, visit our `product website`_.
    guides/compass-cal
    guides/third-party-i2c
    guides/platformio
-   guides/soldering
 ..
+   guides/soldering
    guides/third-party-motors
    guides/motor-pid-cal
    guides/drivebase-pid-cal
@@ -64,8 +64,8 @@ In addition, it contains code from additional open source projects:
 Acknowledgements
 ----------------
 
-We'd like to thank the following people for their contributions to the Kickstarter:
+.. note:: Acknowledgements will be added soon :)
 
-TBA soon! :)
+We'd like to thank the following people for their contributions to the Kickstarter:
 
 Without them, EVN would not exist today.

--- a/docs/sensors/evncoloursensor.rst
+++ b/docs/sensors/evncoloursensor.rst
@@ -84,8 +84,7 @@ Functions
 Reading Raw RGBC Values
 """""""""""""""""""""""
 
-.. function::   uint16_t read(bool blocking = true)
-                uint16_t readClear(bool blocking = true)
+.. function::   uint16_t readClear(bool blocking = true)
 
     Returns raw clear reading from sensor.
 

--- a/docs/sensors/evnimusensor.rst
+++ b/docs/sensors/evnimusensor.rst
@@ -100,8 +100,7 @@ Fused Measurements
 """"""""""""""""""
 .. function::   void update()
 
-.. function::   float read(bool blocking = true)
-                float readYaw(bool blocking = true)
+.. function::   float readYaw(bool blocking = true)
 
     :param blocking: Block function from returning a value until a new reading is obtained. Defaults to ``true``
     :returns: Yaw orientation in degrees

--- a/examples/1. Basics/b) Actuators/moveContinuousServo/moveContinuousServo.ino
+++ b/examples/1. Basics/b) Actuators/moveContinuousServo/moveContinuousServo.ino
@@ -34,17 +34,17 @@ void loop()
     //if button outputs "true", run the servo at different speeds and directions for 4 seconds
     if (board.buttonRead())
     {
-        servo.writeDutyCycle(-1);
+        servo.write(-100);
         delay(1000);
-        servo.writeDutyCycle(-0.5);
+        servo.write(-50);
         delay(1000);
-        servo.writeDutyCycle(0.25);
+        servo.write(25);
         delay(1000);
-        servo.writeDutyCycle(1);
+        servo.write(100);
         delay(1000);
     }
     else
     {
-        servo.writeDutyCycle(0);    //otherwise, stop servo
+        servo.write(0);    //otherwise, stop servo
     }
 }

--- a/examples/2. Projects/bluetoothCar/bluetoothCar.ino
+++ b/examples/2. Projects/bluetoothCar/bluetoothCar.ino
@@ -43,8 +43,8 @@ void loop()
             break;
 
         case 4: //stop
-            left.brake();
-            right.brake();
+            left.stop();
+            right.stop();
             break;
         }
     }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EVN
-version=0.10.3
+version=0.10.4
 author=Heng Teng Yi <tengyi.maker@gmail.com>
 maintainer=Heng Teng Yi <tengyi.maker@gmail.com>
 sentence=Software libraries for EVN Alpha.

--- a/src/EVNAlpha.h
+++ b/src/EVNAlpha.h
@@ -28,9 +28,7 @@ public:
     void begin();
 
     //Button & LED Functions
-    bool read() { return this->buttonRead(); };
     bool buttonRead() { return button_led.read(); };
-    void write(bool state) { this->write(state); };
     void ledWrite(bool state) { if (!button_led.getFlash()) digitalWrite(PIN_LED, state); };
 
     void setMode(uint8_t mode) { button_led.setMode(mode); };
@@ -43,6 +41,7 @@ public:
     bool getLinkMovement() { return button_led.getLinkMovement(); };
     bool getButtonInvert() { return button_led.getButtonInvert(); };
 
+    // not exposed to the user, since flash is used for battery alerts
     // void setFlash(bool enable) { button_led.setFlash(enable); };
     // bool getFlash() { return button_led.getFlash(); };
 

--- a/src/actuators/EVNMotor.cpp
+++ b/src/actuators/EVNMotor.cpp
@@ -167,7 +167,7 @@ void EVNMotor::resetPosition()
 	_encoder.position_offset = getPosition_static(&_encoder);
 }
 
-float EVNMotor::getDPS()
+float EVNMotor::getSpeed()
 {
 	return getDPS_static(&_encoder);
 }
@@ -203,7 +203,7 @@ void EVNMotor::runPWM(float duty_cycle_pct)
 	runPWM_static(&_pid_control, constrain(duty_cycle_pct, -100, 100) * 0.01);
 }
 
-void EVNMotor::runDPS(float dps)
+void EVNMotor::runSpeed(float dps)
 {
 	while (_pid_control.stopAction_static_running);
 	_pid_control.core0_writing = true;
@@ -286,13 +286,13 @@ void EVNMotor::runTime(float dps, uint32_t time_ms, uint8_t stop_action, bool wa
 void EVNMotor::stop()
 {
 	_pid_control.stop_action = STOP_BRAKE;
-	stopAction_static(&_pid_control, &_encoder, micros(), getPosition(), getDPS());
+	stopAction_static(&_pid_control, &_encoder, micros(), getPosition(), getSpeed());
 }
 
 void EVNMotor::coast()
 {
 	_pid_control.stop_action = STOP_COAST;
-	stopAction_static(&_pid_control, &_encoder, micros(), getPosition(), getDPS());
+	stopAction_static(&_pid_control, &_encoder, micros(), getPosition(), getSpeed());
 }
 
 void EVNMotor::hold()
@@ -306,7 +306,7 @@ void EVNMotor::hold()
 
 	_pid_control.core0_writing = false;
 
-	stopAction_static(&_pid_control, &_encoder, micros(), getPosition(), getDPS());
+	stopAction_static(&_pid_control, &_encoder, micros(), getPosition(), getSpeed());
 }
 
 bool EVNMotor::completed()

--- a/src/actuators/EVNMotor.cpp
+++ b/src/actuators/EVNMotor.cpp
@@ -283,7 +283,7 @@ void EVNMotor::runTime(float dps, uint32_t time_ms, uint8_t stop_action, bool wa
 	if (wait) while (!this->completed());
 }
 
-void EVNMotor::brake()
+void EVNMotor::stop()
 {
 	_pid_control.stop_action = STOP_BRAKE;
 	stopAction_static(&_pid_control, &_encoder, micros(), getPosition(), getDPS());
@@ -635,11 +635,6 @@ void EVNDrivebase::driveToXY(float speed, float turn_rate, float x, float y, uin
 }
 
 void EVNDrivebase::stop()
-{
-	this->brake();
-}
-
-void EVNDrivebase::brake()
 {
 	db.stop_action = STOP_BRAKE;
 	stopAction_static(&db);

--- a/src/actuators/EVNMotor.cpp
+++ b/src/actuators/EVNMotor.cpp
@@ -187,7 +187,7 @@ uint8_t EVNMotor::clean_input_stop_action(uint8_t stop_action)
 	return min(2, stop_action);
 }
 
-void EVNMotor::runPWM(float duty_cycle)
+void EVNMotor::runPWM(float duty_cycle_pct)
 {
 	while (_pid_control.stopAction_static_running);
 	_pid_control.core0_writing = true;
@@ -200,7 +200,7 @@ void EVNMotor::runPWM(float duty_cycle)
 
 	_pid_control.core0_writing = false;
 
-	runPWM_static(&_pid_control, duty_cycle);
+	runPWM_static(&_pid_control, constrain(duty_cycle_pct, -100, 100) * 0.01);
 }
 
 void EVNMotor::runDPS(float dps)

--- a/src/actuators/EVNMotor.h
+++ b/src/actuators/EVNMotor.h
@@ -102,8 +102,7 @@ public:
 	float getPosition();
 	float getHeading();
 	void resetPosition();
-	float getDPS();
-	float getSpeed() { return this->getDPS(); };
+	float getSpeed();
 
 	void setPID(float p, float i, float d);
 	void setAccel(float accel_dps_sq);
@@ -112,8 +111,7 @@ public:
 	void setPPR(uint32_t ppr);
 
 	void runPWM(float duty_cycle_pct);
-	void runSpeed(float dps) { this->runDPS(dps); };
-	void runDPS(float dps);
+	void runSpeed(float dps);
 
 	void runPosition(float dps, float position, uint8_t stop_action = STOP_BRAKE, bool wait = true);
 	void runAngle(float dps, float degrees, uint8_t stop_action = STOP_BRAKE, bool wait = true);

--- a/src/actuators/EVNMotor.h
+++ b/src/actuators/EVNMotor.h
@@ -126,7 +126,6 @@ public:
 	//position / target -> -inf - inf
 
 	void stop();
-	void brake();
 	void coast();
 	void hold();
 
@@ -671,7 +670,6 @@ public:
 	void driveToXY(float speed, float turn_rate, float x, float y, uint8_t stop_action = STOP_BRAKE, bool restore_initial_heading = true);
 
 	void stop();
-	void brake();
 	void coast();
 	void hold();
 
@@ -734,8 +732,8 @@ private:
 		switch (arg->stop_action)
 		{
 		case STOP_BRAKE:
-			arg->motor_left->brake();
-			arg->motor_right->brake();
+			arg->motor_left->stop();
+			arg->motor_right->stop();
 			break;
 		case STOP_COAST:
 			arg->motor_left->coast();
@@ -1185,15 +1183,10 @@ public:
 
 	void stop()
 	{
-		this->brake();
-	};
-
-	void brake()
-	{
-		_fl->brake();
-		_fr->brake();
-		_bl->brake();
-		_br->brake();
+		_fl->stop();
+		_fr->stop();
+		_bl->stop();
+		_br->stop();
 	};
 
 	void coast()

--- a/src/actuators/EVNMotor.h
+++ b/src/actuators/EVNMotor.h
@@ -111,7 +111,7 @@ public:
 	void setMaxRPM(float max_rpm);
 	void setPPR(uint32_t ppr);
 
-	void runPWM(float duty_cycle);
+	void runPWM(float duty_cycle_pct);
 	void runSpeed(float dps) { this->runDPS(dps); };
 	void runDPS(float dps);
 

--- a/src/actuators/EVNServo.cpp
+++ b/src/actuators/EVNServo.cpp
@@ -55,11 +55,6 @@ void EVNServo::begin()
 
 void EVNServo::write(float position, uint16_t wait_time_ms, float dps)
 {
-    this->writePosition(position, wait_time_ms, dps);
-}
-
-void EVNServo::writePosition(float position, uint16_t wait_time_ms, float dps)
-{
     if (dps == 0)
     {
         _servo.position = constrain(position, 0, _servo.range);
@@ -132,15 +127,10 @@ void EVNContinuousServo::begin()
     attach_servo_interrupt(&_servo);
 }
 
-void EVNContinuousServo::write(float duty_cycle)
+void EVNContinuousServo::write(float duty_cycle_pct)
 {
-    this->writeDutyCycle(duty_cycle);
-}
-
-void EVNContinuousServo::writeDutyCycle(float duty_cycle)
-{
-    float duty_cyclec = constrain(duty_cycle, -1, 1);
-    uint16_t pulse = (uint16_t)((1 - fabs(duty_cycle)) * (float)(_servo.max_pulse_us - _servo.min_pulse_us) / 2);
+    float duty_cyclec = constrain(duty_cycle_pct, -100, 100) * 0.01;
+    uint16_t pulse = (uint16_t)((1 - fabs(duty_cyclec)) * (float)(_servo.max_pulse_us - _servo.min_pulse_us) / 2);
 
     if ((_servo.servo_dir == DIRECT) == (duty_cyclec > 0))
         pulse = _servo.min_pulse_us + pulse;

--- a/src/actuators/EVNServo.h
+++ b/src/actuators/EVNServo.h
@@ -135,8 +135,7 @@ public:
 
     EVNContinuousServo(uint8_t port, bool servo_dir = DIRECT, uint16_t min_pulse_us = 600, uint16_t max_pulse_us = 2400);
     void begin();
-    void write(float duty_cycle);
-    void writeDutyCycle(float duty_cycle);
+    void write(float duty_cycle_pct);
     void writeMicroseconds(uint16_t pulse_us);
 
 protected:

--- a/src/actuators/EVNServo.h
+++ b/src/actuators/EVNServo.h
@@ -36,7 +36,6 @@ public:
     EVNServo(uint8_t port, bool servo_dir = DIRECT, uint16_t range = 270, float start_position = 135, uint16_t min_pulse_us = 600, uint16_t max_pulse_us = 2400, float max_dps = 500);
     void begin();
     void write(float position, uint16_t wait_time_ms = 0, float dps = 0);
-    void writePosition(float position, uint16_t wait_time_ms = 0, float dps = 0);
     void writeMicroseconds(uint16_t pulse_us, uint16_t wait_time_ms = 0);
     uint16_t getRange() { return _servo.range; };
     float getMaxDPS() { return _servo.max_dps; };

--- a/src/displays/EVNDisplay.h
+++ b/src/displays/EVNDisplay.h
@@ -90,21 +90,7 @@ public:
 
   //alias for writeLabel
   template <typename T>
-  void writeLine(uint8_t row, T line)
-  {
-    this->writeLabel(row, line);
-  };
-
-  //alias for writeLabel
-  template <typename T>
   void print(uint8_t row, T line)
-  {
-    this->writeLabel(row, line);
-  };
-
-  //alias for writeLabel
-  template <typename T>
-  void write(uint8_t row, T line)
   {
     this->writeLabel(row, line);
   };


### PR DESCRIPTION
This is a small update to update docs and make style changes to the library.

Many aliased (duplicate) functions have been removed from the following classes:
* EVNAlpha
* EVNMotor
* EVNDrivebase
* EVNIMUSensor
* EVNColourSensor
* EVNServo
* EVNContinuousServo

More alias functions may be removed in future updates, and some may remain but this will be an exception, not the norm moving forward.

-- Bugfixes --

EVNMotor: stop() was declared but undefined. It has now been defined, and replaces brake() as the braking function. So do not call brake() in your code.