### PR TITLE
Bugfix to allow for dynamic object creation

### DIFF
--- a/examples/1. Basics/b) Actuators/moveFixedServo/moveFixedServo.ino
+++ b/examples/1. Basics/b) Actuators/moveFixedServo/moveFixedServo.ino
@@ -7,7 +7,7 @@ The following program demonstrates some basic EVNServo functionality.
 
 #define SERVO_PORT 1  //set servo port here
 
-EVNAlpha board(BUTTON_TOGGLE, true, true);
+EVNAlpha board;
 EVNServo servo(SERVO_PORT);
 
 //EVNAlpha board(BUTTON_TOGGLE, true, true);

--- a/examples/1. Basics/b) Actuators/moveFixedServo/moveFixedServo.ino
+++ b/examples/1. Basics/b) Actuators/moveFixedServo/moveFixedServo.ino
@@ -34,6 +34,6 @@ void loop()
     if (board.buttonRead())
     {
         servo.write(0, 1000);       //set servo to move to position of 0deg, and wait for 1 second
-        servo.write(270, 9500, 20); //set servo to move to position of 270deg at a speed of 20deg per second, and wait for 5 seconds
+        servo.write(270, 9500, 20); //set servo to move to position of 270deg at a speed of 20deg per second, and wait for 9.5 seconds
     }
 }

--- a/src/actuators/EVNMotor.cpp
+++ b/src/actuators/EVNMotor.cpp
@@ -97,18 +97,18 @@ EVNMotor::EVNMotor(uint8_t port, uint8_t motortype, uint8_t motor_dir, uint8_t e
 	}
 
 	//make sure motor does not run
-	_pid_control.run_pwm = false;
-	_pid_control.hold = false;
-	_pid_control.run_speed = false;
-	_pid_control.run_time = false;
-	_pid_control.run_pos = false;
-	_pid_control.stopAction_static_running = false;
-	_pid_control.core0_writing = false;
+	// _pid_control.run_pwm = false;
+	// _pid_control.hold = false;
+	// _pid_control.run_speed = false;
+	// _pid_control.run_time = false;
+	// _pid_control.run_pos = false;
+	// _pid_control.stopAction_static_running = false;
+	// _pid_control.core0_writing = false;
 
-	_encoder.position = 0;
-	_encoder.position_offset = 0;
-	_encoder.dps_calculated = false;
-	_encoder.obtained_one_pulse = false;
+	// _encoder.position = 0;
+	// _encoder.position_offset = 0;
+	// _encoder.dps_calculated = false;
+	// _encoder.obtained_one_pulse = false;
 }
 
 void EVNMotor::begin()
@@ -355,10 +355,10 @@ EVNDrivebase::EVNDrivebase(float wheel_dia, float axle_track, EVNMotor* motor_le
 
 	db.axle_track = fabs(axle_track);
 	db.wheel_dia = fabs(wheel_dia);
-	db.drive = false;
-	db.drive_position = false;
-	db.stopAction_static_running = false;
-	db.core0_writing = false;
+	// db.drive = false;
+	// db.drive_position = false;
+	// db.stopAction_static_running = false;
+	// db.core0_writing = false;
 
 	db.max_speed = db.max_rpm / 60 * db.wheel_dia * M_PI;
 	db.max_turn_rate = db.max_rpm * 6 * db.wheel_dia / axle_track;

--- a/src/actuators/EVNMotor.cpp
+++ b/src/actuators/EVNMotor.cpp
@@ -95,20 +95,6 @@ EVNMotor::EVNMotor(uint8_t port, uint8_t motortype, uint8_t motor_dir, uint8_t e
 		_encoder.ppr = CUSTOM_PPR;
 		break;
 	}
-
-	//make sure motor does not run
-	// _pid_control.run_pwm = false;
-	// _pid_control.hold = false;
-	// _pid_control.run_speed = false;
-	// _pid_control.run_time = false;
-	// _pid_control.run_pos = false;
-	// _pid_control.stopAction_static_running = false;
-	// _pid_control.core0_writing = false;
-
-	// _encoder.position = 0;
-	// _encoder.position_offset = 0;
-	// _encoder.dps_calculated = false;
-	// _encoder.obtained_one_pulse = false;
 }
 
 void EVNMotor::begin()
@@ -355,10 +341,6 @@ EVNDrivebase::EVNDrivebase(float wheel_dia, float axle_track, EVNMotor* motor_le
 
 	db.axle_track = fabs(axle_track);
 	db.wheel_dia = fabs(wheel_dia);
-	// db.drive = false;
-	// db.drive_position = false;
-	// db.stopAction_static_running = false;
-	// db.core0_writing = false;
 
 	db.max_speed = db.max_rpm / 60 * db.wheel_dia * M_PI;
 	db.max_turn_rate = db.max_rpm * 6 * db.wheel_dia / axle_track;

--- a/src/actuators/EVNMotor.h
+++ b/src/actuators/EVNMotor.h
@@ -134,8 +134,8 @@ protected:
 	uint8_t clean_input_dir(float dps);
 	uint8_t clean_input_stop_action(uint8_t stop_action);
 
-	pid_control_t _pid_control;
-	encoder_state_t _encoder;
+	pid_control_t _pid_control = {};
+	encoder_state_t _encoder = {};
 
 	static bool ports_started[4];
 	static encoder_state_t* encoderArgs[4]; // static list of pointers to each instances' structs
@@ -680,7 +680,7 @@ private:
 	float radius_to_turn_rate(float speed, float radius);
 	void enable_drive_position(uint8_t stop_action, bool wait);
 
-	drivebase_state_t db;
+	drivebase_state_t db = {};
 	static drivebase_state_t* dbArgs[MAX_DB_OBJECTS];
 	static bool dbs_enabled[MAX_DB_OBJECTS];
 

--- a/src/actuators/EVNServo.cpp
+++ b/src/actuators/EVNServo.cpp
@@ -12,11 +12,8 @@ EVNServo::EVNServo(uint8_t port, bool servo_dir, uint16_t range, float start_pos
     _servo.range = range;
     _servo.min_pulse_us = min_pulse_us;
     _servo.max_pulse_us = max_pulse_us;
-    _servo.dps = 0;
     _servo.max_dps = max(1, max_dps);
     _servo.position = constrain(start_position, 0, range);
-    _servo.end_position = 0;
-    _servo.sweep = false;
 
     uint8_t portc = constrain(port, 1, 4);
     _servo.port = portc;

--- a/src/actuators/EVNServo.h
+++ b/src/actuators/EVNServo.h
@@ -42,7 +42,7 @@ public:
     float getMaxDPS() { return _servo.max_dps; };
 
 protected:
-    servo_state_t _servo;
+    servo_state_t _servo = {};
     static servo_state_t* servoArgs[4];
     static bool servos_enabled[4];
     static bool cservos_enabled[4];


### PR DESCRIPTION
Structs were not initialized to 0 when created in local scope, causing major instability. Should be fixed for the following classes:

- EVNMotor
- EVNDrivebase
- EVNServo
- EVNContinuousServo

Other peripheral classes do not use structs, but if there are similar issues with variables initializing with wrong values, we'll fix them soon.