### PR TITLE
Version 1.0.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.0.2 (22/09/24)
+
+-- Bugfixes --
+
+EVNMotor, EVNDrivebase: Fix important bug where encoder pulses were skipped, leading to inaccurate encoder readings and sudden changes in motor direction when running, especially when using EVNDrivebase
+
 1.0.1 (22/09/24)
 
 Bugfix update for the recent major release

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EVN
-version=1.0.1
+version=1.0.2
 author=Heng Teng Yi <tengyi.maker@gmail.com>
 maintainer=Heng Teng Yi <tengyi.maker@gmail.com>
 sentence=Software libraries for EVN Alpha.

--- a/src/helper/EVNISRTimer.cpp
+++ b/src/helper/EVNISRTimer.cpp
@@ -4,7 +4,6 @@ repeating_timer_t EVNISRTimer0::timers[16];
 alarm_pool_t* EVNISRTimer0::pool;
 bool EVNISRTimer0::_started = false;
 
-
 repeating_timer_t EVNISRTimer1::timers[16];
 alarm_pool_t* EVNISRTimer1::pool;
 bool EVNISRTimer1::_started = false;

--- a/src/helper/EVNISRTimer.h
+++ b/src/helper/EVNISRTimer.h
@@ -17,6 +17,7 @@ public:
         {
             _started = true;
             pool = alarm_pool_create(CORE0_TIMER_NUM, 16);
+            irq_set_priority(TIMER_IRQ_1, 0xC0);
         }
     };
 
@@ -32,7 +33,7 @@ private:
 class EVNISRTimer1
 {
 public:
-    static const uint8_t  CORE1_TIMER_NUM = 2;
+    static const uint8_t CORE1_TIMER_NUM = 2;
 
     EVNISRTimer1() {};
     void begin()
@@ -41,6 +42,7 @@ public:
         {
             _started = true;
             pool = alarm_pool_create(CORE1_TIMER_NUM, 16);
+            irq_set_priority(TIMER_IRQ_2, 0xC0);
         }
     };
 


### PR DESCRIPTION
1.0.2 (22/09/24)

-- Bugfixes --

EVNMotor, EVNDrivebase: Fix important bug where encoder pulses were skipped, leading to inaccurate encoder readings and sudden changes in motor direction when running, especially when using EVNDrivebase