### PR TITLE
Version 1.1.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.1.2 (10/11/24)
+
+-- Bugfixes --
+
+EVNDrivebase: PID tunings changed to make the class more usable for NXT and EV3 Large Motors. Completion thresholds for drive-to-endpoint functions have also been relaxed (1deg allowable error to 2deg). Expect better tunings in the near future!
+
 1.1.1 (9/11/24)
 
 -- Features --

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EVN
-version=1.1.1
+version=1.1.2
 author=Heng Teng Yi <tengyi.maker@gmail.com>
 maintainer=Heng Teng Yi <tengyi.maker@gmail.com>
 sentence=Software libraries for EVN Alpha.

--- a/src/actuators/EVNMotor.cpp
+++ b/src/actuators/EVNMotor.cpp
@@ -445,8 +445,8 @@ EVNDrivebase::EVNDrivebase(float wheel_dia, float axle_track, EVNMotor* motor_le
 	db.max_speed = db.max_rpm / 60 * db.wheel_dia * M_PI;
 	db.max_turn_rate = db.max_rpm * 6 * db.wheel_dia / db.axle_track;
 	db.max_dps = db.max_rpm * 6;
-	db.max_distance_error = USER_DRIVE_POS_MIN_ERROR_MOTOR_DEG * db.wheel_dia * M_PI / 720;
-	db.max_angle_error = USER_DRIVE_POS_MIN_ERROR_MOTOR_DEG * db.wheel_dia / (2 * db.axle_track);
+	db.max_distance_error = USER_DRIVE_POS_MIN_ERROR_MOTOR_DEG * db.wheel_dia * M_PI / 360;
+	db.max_angle_error = USER_DRIVE_POS_MIN_ERROR_MOTOR_DEG * db.wheel_dia / db.axle_track;
 
 	db.turn_rate_pid = new PIDController(DRIVEBASE_KP_TURN_RATE, DRIVEBASE_KI_TURN_RATE, DRIVEBASE_KD_TURN_RATE, DIRECT);
 	db.speed_pid = new PIDController(DRIVEBASE_KP_SPEED, DRIVEBASE_KI_SPEED, DRIVEBASE_KD_SPEED, DIRECT);

--- a/src/evn_motor_defs.h
+++ b/src/evn_motor_defs.h
@@ -35,21 +35,19 @@
 #define NXT_LARGE_ACCEL         155 * 600
 #define NXT_LARGE_DECEL         155 * 600
 
-//TUNING FOR EVN MOTOR CLASS
-#define USER_RUN_DEGREES_MIN_LOOP_COUNT     1
-#define USER_RUN_DEGREES_MIN_ERROR_DEG      0.5
+//TUNING FOR EVNMOTOR CLASS
+#define USER_RUN_DEGREES_MIN_ERROR_MOTOR_DEG    0.5
 
-//TUNING FOR EVN DRIVEBASE CLASS
-#define USER_DRIVE_POS_MIN_LOOP_COUNT       2
-#define USER_DRIVE_POS_MIN_ERROR_MOTOR_DEG  2
+//TUNING FOR EVNDRIVEBASE CLASS
+#define USER_DRIVE_POS_MIN_ERROR_MOTOR_DEG      2
 
-#define DRIVEBASE_KP_SPEED                  12.5
-#define DRIVEBASE_KI_SPEED                  0.000125
-#define DRIVEBASE_KD_SPEED                  12.5
+#define DRIVEBASE_KP_SPEED                  6.25
+#define DRIVEBASE_KI_SPEED                  0.0000625
+#define DRIVEBASE_KD_SPEED                  3.125
 
-#define DRIVEBASE_KP_TURN_RATE              6000
-#define DRIVEBASE_KI_TURN_RATE              0.06
-#define DRIVEBASE_KD_TURN_RATE              24000
+#define DRIVEBASE_KP_TURN_RATE              6.25
+#define DRIVEBASE_KI_TURN_RATE              0.00003125
+#define DRIVEBASE_KD_TURN_RATE              12.5
 
 #define USER_SPEED_ACCEL                    500
 #define USER_SPEED_DECEL                    500


### PR DESCRIPTION
1.1.2 (10/11/24)

-- Bugfixes --

EVNDrivebase: PID tunings changed to make the class more usable for NXT and EV3 Large Motors. Completion thresholds for drive-to-endpoint functions have also been relaxed (1deg allowable error to 2deg). Expect better tunings in the near future!