### PR TITLE
Version 1.1.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+1.1.3 (14/11/24)
+
+-- Bugfixes --
+
+EVNMotor: PID tunings for NXT and EV3 Motors improved. Hold is now much more stable as well, with lower settling time and less glitches.
+
+EVNDrivebase: 
+
+Previously, if drive functions were called right after the stop/coast/hold functions, EVNDrivebase would encounter sudden jerks, some of them prolonged.
+
+This occurs because the controllers are unable to properly control the motors mid-pause. This issue has been rectified with a "stop-check", which ensures that after stop commands are issued, the controller will not begin further commands until the motors have actually stopped.
+
+During the stop-check, EVNDrivebase can still receive commands from the user, but it will just start performing those commands when the stop-check is done. Drive-to-endpoint positions with wait enabled and stop/coast/hold functions will also stall the main core until the drivebase has paused or the stop check times out (conversely, drive forever, drive-to-endpoint with no wait enabled will not).
+
+The stop check thresholds and timeout values being configurable in src/evn_motor_defs.h. We hope this will significantly improve your EVN experience :)
+
 1.1.2 (10/11/24)
 
 -- Bugfixes --

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EVN
-version=1.1.2
+version=1.1.3
 author=Heng Teng Yi <tengyi.maker@gmail.com>
 maintainer=Heng Teng Yi <tengyi.maker@gmail.com>
 sentence=Software libraries for EVN Alpha.

--- a/src/evn_motor_defs.h
+++ b/src/evn_motor_defs.h
@@ -12,8 +12,8 @@
 #define LEGO_PPR				180
 
 //TUNING FOR LEGO EV3 LARGE SERVO MOTOR
-#define KP_EV3_LARGE            0.35
-#define KI_EV3_LARGE	        0.00035
+#define KP_EV3_LARGE            0.25
+#define KI_EV3_LARGE	        0.0000125
 #define KD_MAX_EV3_LARGE	    2.45
 #define EV3_LARGE_MAX_RPM		155
 #define EV3_LARGE_ACCEL         155 * 600
@@ -21,15 +21,15 @@
 
 //TUNING FOR LEGO EV3 MEDIUM SERVO MOTOR
 #define KP_EV3_MED	            0.16
-#define KI_EV3_MED	            0.00016
+#define KI_EV3_MED	            0.000008
 #define KD_MAX_EV3_MED	        1.3
 #define EV3_MED_MAX_RPM			245
 #define EV3_MED_ACCEL           245 * 600
 #define EV3_MED_DECEL           245 * 600
 
 //TUNING FOR LEGO NXT LARGE SERVO MOTOR
-#define KP_NXT_LARGE	        0.35
-#define KI_NXT_LARGE	        0.00035
+#define KP_NXT_LARGE	        0.25
+#define KI_NXT_LARGE	        0.0000125
 #define KD_MAX_NXT_LARGE	    2.45
 #define NXT_LARGE_MAX_RPM		155
 #define NXT_LARGE_ACCEL         155 * 600
@@ -40,9 +40,11 @@
 
 //TUNING FOR EVNDRIVEBASE CLASS
 #define USER_DRIVE_POS_MIN_ERROR_MOTOR_DEG      2
+#define USER_DRIVE_STOP_CHECK_THRESHOLD_DPS     20
+#define USER_DRIVE_STOP_CHECK_TIMEOUT_US        500000
 
 #define DRIVEBASE_KP_SPEED                  6.25
-#define DRIVEBASE_KI_SPEED                  0.0000625
+#define DRIVEBASE_KI_SPEED                  0.00003125
 #define DRIVEBASE_KD_SPEED                  3.125
 
 #define DRIVEBASE_KP_TURN_RATE              6.25


### PR DESCRIPTION
1.1.3 (14/11/24)

-- Bugfixes --

EVNMotor: PID tunings for NXT and EV3 Motors improved. Hold is now much more stable as well, with lower settling time and less glitches.

EVNDrivebase: 

Previously, if drive functions were called right after the stop/coast/hold functions, EVNDrivebase would encounter sudden jerks, some of them prolonged.

This occurs because the controllers are unable to properly control the motors mid-pause. This issue has been rectified with a "stop-check", which ensures that after stop commands are issued, the controller will not begin further commands until the motors have actually stopped.

During the stop-check, EVNDrivebase can still receive commands from the user, but it will just start performing those commands when the stop-check is done. Drive-to-endpoint positions with wait enabled and stop/coast/hold functions will also stall the main core until the drivebase has paused or the stop check times out (conversely, drive forever, drive-to-endpoint with no wait enabled will not).

The stop check thresholds and timeout values being configurable in src/evn_motor_defs.h. We hope this will significantly improve your EVN experience :)
