### PR TITLE
Version 1.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,38 @@
+1.2.0 (08/12/24)
+
+In this update, we've made several changes (some of them breaking) to the sensor classes in the hopes of making them more approachable for end-users, despite the many sensor settings options made available for them. Additionally, this update fixes urgent bugs for EVNDrivebase (on the latest versions of the Arduino-Pico core) and EVNContinuousServo.
+
+Currently, we're working on obtaining better PID tunings for EVNMotor and EVNDrivebase for better line-tracking performance. Expect that sometime soon :)
+
+-- Features --
+
+EVNColourSensor, EVNCompassSensor, EVNGestureSensor, EVNIMUSensor, EVNEnvSensor:
+
+For these classes, we adopted the convention of using enums in the class as inputs to set sensor settings (e.g. EVNColourSensor::gain::X4). Given the sheer number of settings, the lengthy wording and possible confusion of using enums, we have decided to add #defines that abbreviate the enums into shorter, simpler terms for the user to pass as input.
+
+For instance, for EVNColourSensor, instead of calling sensor.setGain(EVNColourSensor::gain::X1), the user may now sensor.setGain(COLOUR_GAIN_X1), which is shorter and less confusing.
+
+These additions will not break existing code; the #defines will get converted to the enums during compilation. However, there are some changes or removals of certain enums that will break existing code, detailed more closely below.
+
+-- Changes --
+
+EVNMotor: The behaviour of runAngle() when given negative inputs has been standardised and clarified in docs
+EVNDrivebase: The behaviour of curve(), curveTurnRate() and straight() when given negative inputs has been standardised and clarified in docs
+EVNIMUSensor: Constructor now contains 3 additional input parameters for sensor settings
+EVNEnvSensor: Constructor now contains 5 additional input parameters for sensor settings (docs were previously outdated)
+
+-- BREAKING Changes --
+EVNCompassSensor: hmc_samples and qmc_samples enums have been renamed to hmc_sampling and qmc_sampling. This will break existing code that sets the sensor sampling rate, and should be changed to use the newly added #defines.
+EVNCompassSensor: setSamplesQMC() and setSamplesHMC() renamed to setSamplingRateQMC() and setSamplingRateHMC() respectively
+EVNCompassSensor: setModeQMC() and setModeHMC() combined into one function setMode()
+
+EVNCompassSensor, EVNEnvSensor: setMode() now receives a boolean (instead of enum) indicating whether to enable/disable measurement. This will break existing code that sets sensor mode, and should be changed to use booleans instead.
+
+-- Bugfixes --
+
+EVNDrivebase: Fixed bug for Arduino-Pico >=4.3.0 where begin() would crash
+EVNContinuousServo: Fixed compilation errors
+
 1.1.3 (14/11/24)
 
 -- Bugfixes --

--- a/docs/actuators/evndrivebase.rst
+++ b/docs/actuators/evndrivebase.rst
@@ -177,7 +177,9 @@ Move by a Fixed Amount
 
 .. function:: void straight(float speed, float distance, uint8_t stop_action = STOP_BRAKE, bool wait = true);
 
-    Runs drivebase in a straight line for the specified distance, then performs given stop action
+    Runs drivebase in a straight line for the specified distance, then performs given stop action.
+
+    Drivebase speed direction is reversed when the ``speed`` or ``distance`` inputs are negative (e.g. ``straight(100, -100)``, ``straight(-100, 100)``, or ``straight(-100, -100)`` will all move the drivebase backwards).
 
     :param speed: Velocity of drivebase (in mm/s)
     :param distance: Distance to travel (in mm)
@@ -197,7 +199,9 @@ Move by a Fixed Amount
 .. function::   void curve(float speed, float radius, float angle, uint8_t stop_action = STOP_BRAKE, bool wait = true);
                 void curveRadius(float speed, float radius, float angle, uint8_t stop_action = STOP_BRAKE, bool wait = true);
 
-    Runs drivebase in a curve of specified radius until its heading has shifted by the given angle, then performs given stop action
+    Runs drivebase in a curve of specified radius until its heading has shifted by the given angle, then performs given stop action.
+
+    Drivebase turning direction is reversed when the ``radius`` or ``angle`` inputs are negative (e.g. ``curve(100, 100, -100)``, ``curve(100, -100, 100)``, or ``curve(100, -100, -100)`` will all use a negative (clockwise) turning rate).
 
     :param speed: Velocity of drivebase (in mm/s)
     :param radius: Turning radius of drivebase (in mm)
@@ -218,6 +222,8 @@ Move by a Fixed Amount
 .. function:: void curveTurnRate(float speed, float turn_rate, float angle, uint8_t stop_action = STOP_BRAKE, bool wait = true);
 
     Runs drivebase at given speed and turn rate until its heading has shifted by the given angle, then runs specified stop action
+
+    Drivebase turning direction is reversed when the ``turn_rate`` or ``angle`` inputs are negative (e.g. ``curveTurnRate(100, 100, -100)``, ``curveTurnRate(100, -100, 100)``, or ``curveTurnRate(100, -100, -100)`` will all use a negative (clockwise) turning rate).
 
     :param speed: Velocity of drivebase (in mm/s)
     :param turn_rate: Turning rate of drivebase (in deg/s)

--- a/docs/actuators/evnmotor.rst
+++ b/docs/actuators/evnmotor.rst
@@ -15,11 +15,11 @@ We have built-in motor profiles for NXT Large Motors, EV3 Medium Motors and EV3 
 Constructor
 -----------
 
-.. class:: EVNMotor(uint8_t port, uint8_t motortype = EV3_LARGE, uint8_t motor_dir = DIRECT, uint8_t enc_dir = DIRECT)
+.. class:: EVNMotor(uint8_t port, uint8_t motor_type = EV3_LARGE, uint8_t motor_dir = DIRECT, uint8_t enc_dir = DIRECT)
     
     :param port: Port the motor is connected to (1 - 4)
     
-    :param motortype: Type of motor connected. Defaults to ``EV3_LARGE``
+    :param motor_type: Type of motor connected. Defaults to ``EV3_LARGE``
 
         * ``EV3_LARGE`` - EV3 Large Servo Motor
         * ``EV3_MED`` - EV3 Medium Servo Motor

--- a/docs/actuators/evnmotor.rst
+++ b/docs/actuators/evnmotor.rst
@@ -146,6 +146,8 @@ Run by a Fixed Amount
 
     Run motor by the given angle (relative to its starting position), then performs the given stop action.
 
+    Motor direction is reversed when the ``degrees`` or ``dps`` inputs are negative (e.g. ``runAngle(100, -100)``, ``runAngle(-100, 100)``, or ``runAngle(-100, -100)`` will all run the motor in reverse).
+
     :param dps: Angular velocity to run the motor at (in DPS)
     :param degrees: Angular displacement which the motor has to travel (in degrees)
     :param stop_action: Behaviour of the motor upon completing its command. Defaults to ``STOP_BRAKE``
@@ -183,6 +185,8 @@ Run by a Fixed Amount
 .. function:: void runHeading(float dps, float heading, uint8_t stop_action = STOP_BRAKE, bool wait = true)
 
     Run motor to the specified motor shaft heading, then performs the given stop action.
+
+    Motor direction will be automatically computed to minimize the rotation needed to achieve the correct heading.
 
     :param dps: Angular velocity to run the motor at (in DPS)
     :param time_ms: Heading which the motor has to travel to (0 - 360 degrees)

--- a/docs/getting-started/standard-peripherals.rst
+++ b/docs/getting-started/standard-peripherals.rst
@@ -48,19 +48,24 @@ Standard Peripherals each come with a cable to connect to Alpha.
 
 * The 270 Degree Servo and Continuous Servo Peripherals come with non-removable 3-Wire cables.
 
-At one end of the cable, all the wires will be joined into one plastic connector. 
-With the exception of the Servo Peripherals, this connector plugs into the EVN Alpha brick, and has a notch to avoid being plugged in reverse (called a **key**).
+At one end of the cable, all the wires will be joined into one 4-pin connector, which plugs into EVN Alpha. 
+
 The wire colours are also colour-coded to match the pin layout of the ports on EVN Alpha.
+
+.. note::
+
+  As of November 2024, we no longer ship cables with keyed connectors (with a notch) due to availability issues. 
+  This means our cables are essentially 4-pin to 4 * 1-pin Dupont cables.
+  However, we will ensure that the keyed cables that we have shipped will remain compatible with any future shell revisions.
 
 On the other end of the cable, each wire is separated from the others. They all need to be connected to the Peripheral, but they're not joined together
 because the layout of the pins differs with each Peripheral.
 
 The library reference page for each Peripheral (linked below) contains a pin layout section to guide you on the connections.
 
-The pins we used on the Alpha and Standard Peripherals are standard 2.54mm pitch pin headers, and the cables can be substituted with 2.54mm Dupont jumper wires as well! 
-Jumper cables don't have a key, so you'll need to be slightly more careful with your wiring, but they will work perfectly. 
+The pins we used on the Alpha and Standard Peripherals are standard 2.54mm pitch pin headers, and the cables can be substituted with normal 2.54mm Dupont jumper wires as well! 
 
-Likewise, our cables will function well for interfacing with non-Standard Peripherals if they also have 2.54mm pitch pins.
+Likewise, our cables can be used to interface with non-Standard Peripherals with 2.54mm pitch pins.
 
 Wiring
 --------

--- a/docs/sensors/evncoloursensor.rst
+++ b/docs/sensors/evncoloursensor.rst
@@ -28,13 +28,13 @@ SDA   SDA         I2C Serial Data
 Constructor
 -----------
 
-.. class:: EVNColourSensor(uint8_t port, uint8_t integration_cycles = 1, gain gain = gain::X16)
+.. class:: EVNColourSensor(uint8_t port, uint8_t integration_cycles = 1, gain gain = COLOUR_GAIN_X16)
 
     The listed default settings for the sensor are listed here. Refer to ``setGain()`` & ``setIntegrationTime()`` for more information.
 
     :param port: I2C port the sensor is connected to (1-16)
     :param integration_cycles: Number of 2.4ms integration cycle for one reading. Defaults to 1
-    :param gain: Gain applied to readings. Defaults to ``EVNColourSensor::gain::X16``
+    :param gain: Gain applied to readings. Defaults to ``COLOUR_GAIN_X16``
 
 Functions
 ---------
@@ -54,10 +54,10 @@ Functions
 
     :param gain: Gain applied to readings
 
-        * ``EVNColourSensor::gain::X1`` -- 1x gain
-        * ``EVNColourSensor::gain::X4`` -- 4x gain
-        * ``EVNColourSensor::gain::X16`` -- 16x gain
-        * ``EVNColourSensor::gain::X60`` -- 60x gain
+        * ``COLOUR_GAIN_X1`` -- 1x gain
+        * ``COLOUR_GAIN_X4`` -- 4x gain
+        * ``COLOUR_GAIN_X16`` -- 16x gain
+        * ``COLOUR_GAIN_X60`` -- 60x gain
 
 .. function:: void setIntegrationCycles(uint8_t integration_cycles)
 
@@ -76,10 +76,10 @@ Functions
 
     :param gain: Gain applied to readings
 
-        * ``EVNColourSensor::gain::X1`` -- 1x gain
-        * ``EVNColourSensor::gain::X4`` -- 4x gain
-        * ``EVNColourSensor::gain::X16`` -- 16x gain
-        * ``EVNColourSensor::gain::X60`` -- 60x gain
+        * ``COLOUR_GAIN_X1`` -- 1x gain
+        * ``COLOUR_GAIN_X4`` -- 4x gain
+        * ``COLOUR_GAIN_X16`` -- 16x gain
+        * ``COLOUR_GAIN_X60`` -- 60x gain
 
 Reading Raw RGBC Values
 """""""""""""""""""""""

--- a/docs/sensors/evncompasssensor.rst
+++ b/docs/sensors/evncompasssensor.rst
@@ -32,7 +32,7 @@ Constructor
 -----------
 
 .. class:: EVNCompassSensor(uint8_t port, float hard_x = 0, float hard_y = 0, float hard_z = 0, float soft_x_0 = 1, float soft_x_1 = 0, float soft_x_2 = 0, float soft_y_0 = 0, float soft_y_1 = 1, float soft_y_2 = 0, float soft_z_0 = 0, float soft_z_1 = 0, float soft_z_2 = 1)
-  
+
     :param port: I2C port the sensor is connected to (1-16)
     :param hard_x: X-axis hard iron calibration value. Defaults to 0
     :param hard_y: Y-axis hard iron calibration value. Defaults to 0
@@ -46,6 +46,18 @@ Constructor
     :param soft_z_0: Z-axis soft iron calibration value 0. Defaults to 0
     :param soft_z_1: Z-axis soft iron calibration value 1. Defaults to 0
     :param soft_z_2: Z-axis soft iron calibration value 2. Defaults to 1
+
+Since advanced sensor settings are different depending on which sensor model you have, sensor settings can only be changed using the functions below.
+
+These are the defaults:
+    * QMC Model:
+        * Data Rate: ``COMPASS_QMC_HZ_200``
+        * Range: ``COMPASS_QMC_GA_2``
+        * Samples per Reading: ``COMPASS_QMC_X512``
+    * HMC Model:
+        * Data Rate: ``COMPASS_HMC_HZ_75``
+        * Range: ``COMPASS_HMC_GA_4``
+        * Samples per Reading: ``COMPASS_HMC_X1``
 
 Functions
 ---------
@@ -134,6 +146,12 @@ Reading Magnetometer Values
 Sensor Settings
 """"""""""""""""
 
+.. function:: void setMode(bool enable)
+
+    Sets mode to run sensor in
+
+    :param enable: Whether measurement is enabled
+
 The compass measures along 3 different axes (X, Y and Z). This image depicts the 3 axes of the sensor.
 As a quick reference, the sensor PCB has markings for the X and Y axis.
 By default, the X axis is set as the axis passing through the front of the robot, and the Z axis as the axis passing through the top of the robot.
@@ -159,78 +177,64 @@ However, the Compass Sensor Standard Peripheral can be mounted in many orientati
 Advanced Sensor Settings (HMC)
 """""""""""""""""""""""""""""""
 
-.. function:: void setModeHMC(hmc_mode mode)
-
-    :param mode: Mode to run sensor in
-
-    * ``EVNCompassSensor::hmc_mode::CONTINUOUS`` (measurement enabled)
-    * ``EVNCompassSensor::hmc_mode::STANDBY`` (measurement disabled)
-
 .. function:: void setDataRateHMC(hmc_data_rate data_rate)
 
     :param data_rate: Rate at which the sensor takes measurements
 
-    * ``EVNCompassSensor::hmc_data_rate::HZ_0_75`` (0.75Hz)
-    * ``EVNCompassSensor::hmc_data_rate::HZ_1_5`` (1.5Hz)
-    * ``EVNCompassSensor::hmc_data_rate::HZ_3`` (3Hz)
-    * ``EVNCompassSensor::hmc_data_rate::HZ_7_5`` (7.5Hz)
-    * ``EVNCompassSensor::hmc_data_rate::HZ_15`` (15Hz)
-    * ``EVNCompassSensor::hmc_data_rate::HZ_30`` (30Hz)
-    * ``EVNCompassSensor::hmc_data_rate::HZ_75`` (75Hz)
+    * ``COMPASS_HMC_HZ_0_75`` (0.75Hz)
+    * ``COMPASS_HMC_HZ_1_5`` (1.5Hz)
+    * ``COMPASS_HMC_HZ_3`` (3Hz)
+    * ``COMPASS_HMC_HZ_7_5`` (7.5Hz)
+    * ``COMPASS_HMC_HZ_15`` (15Hz)
+    * ``COMPASS_HMC_HZ_30`` (30Hz)
+    * ``COMPASS_HMC_HZ_75`` (75Hz)
 
 .. function:: void setRangeHMC(hmc_range range)
 
     :param range: Measurable magnetic range of readings (in Gauss)
 
-    * ``EVNCompassSensor::hmc_range::GA_0_88`` (+-0.88Ga)
-    * ``EVNCompassSensor::hmc_range::GA_1_3`` (+-1.3Ga)
-    * ``EVNCompassSensor::hmc_range::GA_1_9`` (+-1.9Ga)
-    * ``EVNCompassSensor::hmc_range::GA_2_5`` (+-2.5Ga)
-    * ``EVNCompassSensor::hmc_range::GA_4`` (+-4Ga)
-    * ``EVNCompassSensor::hmc_range::GA_4_7`` (+-4.7Ga)
-    * ``EVNCompassSensor::hmc_range::GA_5_6`` (+-5.6Ga)
-    * ``EVNCompassSensor::hmc_range::GA_8_1`` (+-8.1Ga)
+    * ``COMPASS_HMC_GA_0_88`` (+-0.88Ga)
+    * ``COMPASS_HMC_GA_1_3`` (+-1.3Ga)
+    * ``COMPASS_HMC_GA_1_9`` (+-1.9Ga)
+    * ``COMPASS_HMC_GA_2_5`` (+-2.5Ga)
+    * ``COMPASS_HMC_GA_4`` (+-4Ga)
+    * ``COMPASS_HMC_GA_4_7`` (+-4.7Ga)
+    * ``COMPASS_HMC_GA_5_6`` (+-5.6Ga)
+    * ``COMPASS_HMC_GA_8_1`` (+-8.1Ga)
 
-.. function:: void setSamplesHMC(hmc_samples samples)
+.. function:: void setSamplingRateHMC(hmc_sampling samples)
 
     :param samples: Number of samples taken per reading
 
-    * ``EVNCompassSensor::hmc_samples::X1`` (1)
-    * ``EVNCompassSensor::hmc_samples::X2`` (2)
-    * ``EVNCompassSensor::hmc_samples::X3`` (3)
-    * ``EVNCompassSensor::hmc_samples::X4`` (4)
+    * ``COMPASS_HMC_SAMPLING_X1`` (1)
+    * ``COMPASS_HMC_SAMPLING_X2`` (2)
+    * ``COMPASS_HMC_SAMPLING_X4`` (4)
+    * ``COMPASS_HMC_SAMPLING_X8`` (8)
 
 Advanced Sensor Settings (QMC)
 """"""""""""""""""""""""""""""
-
-.. function:: void setModeQMC(qmc_mode mode)
-
-    :param mode: Mode to run sensor in
-
-    * ``EVNCompassSensor::qmc_mode::CONTINUOUS`` (measurement enabled)
-    * ``EVNCompassSensor::qmc_mode::STANDBY`` (measurement disabled)
 
 .. function:: void setDataRateQMC(qmc_data_rate data_rate)
 
     :param data_rate: Rate at which the sensor takes measurements
 
-    * ``EVNCompassSensor::qmc_data_rate::HZ_10`` (10Hz)
-    * ``EVNCompassSensor::qmc_data_rate::HZ_50`` (50Hz)
-    * ``EVNCompassSensor::qmc_data_rate::HZ_100`` (100Hz)
-    * ``EVNCompassSensor::qmc_data_rate::HZ_200`` (200Hz)
+    * ``COMPASS_QMC_HZ_10`` (10Hz)
+    * ``COMPASS_QMC_HZ_50`` (50Hz)
+    * ``COMPASS_QMC_HZ_100`` (100Hz)
+    * ``COMPASS_QMC_HZ_200`` (200Hz)
 
 .. function:: void setRangeQMC(qmc_range range)
 
     :param range: Measurable magnetic range of readings (in Gauss)
 
-    * ``EVNCompassSensor::qmc_range::GA_2`` (+-2Ga)
-    * ``EVNCompassSensor::qmc_range::GA_8`` (+-8Ga)
+    * ``COMPASS_QMC_GA_2`` (+-2Ga)
+    * ``COMPASS_QMC_GA_8`` (+-8Ga)
 
-.. function:: void setSamplesQMC(qmc_samples samples)
+.. function:: void setSamplingRateQMC(qmc_sampling samples)
 
     :param samples: Number of samples taken per reading
 
-    * ``EVNCompassSensor::qmc_samples::X64`` (64)
-    * ``EVNCompassSensor::qmc_samples::X128`` (128)
-    * ``EVNCompassSensor::qmc_samples::X256`` (256)
-    * ``EVNCompassSensor::qmc_samples::X512`` (512)
+    * ``COMPASS_QMC_SAMPLING_X64`` (64)
+    * ``COMPASS_QMC_SAMPLING_X128`` (128)
+    * ``COMPASS_QMC_SAMPLING_X256`` (256)
+    * ``COMPASS_QMC_SAMPLING_X512`` (512)

--- a/docs/sensors/evnenvsensor.rst
+++ b/docs/sensors/evnenvsensor.rst
@@ -26,23 +26,14 @@ SDA   SDA         I2C Serial Data
 Constructor
 -----------
 
-.. class:: EVNEnvSensor(uint8_t port, mode mode = mode::NORMAL, sampling sampling_temp = sampling::X1, sampling sampling_pres = sampling::X1, sampling sampling_hum = sampling::X1, filter filter = filter::OFF, standby standby = standby::MS_0_5)
-
-    The listed default settings for the sensor are listed here. Refer to ``writeSettings()`` for more information.
+.. class:: EVNEnvSensor(uint8_t port, sampling sampling_temp = ENV_SAMPLING_X1, sampling sampling_pres = ENV_SAMPLING_X1, sampling sampling_hum = ENV_SAMPLING_X1, filter filter = ENV_FILTER_OFF, standby standby = ENV_STANDBY_MS_0_5)
 
     :param port: I2C port the sensor is connected to (1-16)
-
-    :param mode: Mode to run sensor in. Defaults to ``EVNEnvSensor::mode::NORMAL``
-
-    :param sampling_temp: Sampling rate for temperature. Defaults to ``EVNEnvSensor::sampling::X1``
-
-    :param sampling_pres: Sampling rate for pressure. Defaults to ``EVNEnvSensor::sampling::X1``
-
-    :param sampling_hum: Sampling rate for humidity. Defaults to ``EVNEnvSensor::sampling::X1``
-
-    :param filter: Filter rate applied to readings. Defaults to ``EVNEnvSensor::filter::OFF``
-        
-    :param standby: Standby time between end of reading and start of new reading (in ms). Defaults to ``EVNEnvSensor::standby::MS_0_5``
+    :param sampling_temp: Sampling rate for temperature. Defaults to ``ENV_SAMPLING_X1``
+    :param sampling_pres: Sampling rate for pressure. Defaults to ``ENV_SAMPLING_X1``
+    :param sampling_hum: Sampling rate for humidity. Defaults to ``ENV_SAMPLING_X1``
+    :param filter: Filter rate applied to readings. Defaults to ``ENV_FILTER_OFF``
+    :param standby: Standby time between end of reading and start of new reading (in ms). Defaults to ``ENV_STANDBY_MS_0_5``
 
 Functions
 ---------
@@ -134,14 +125,11 @@ Reading Pressure & Altitude
 Advanced Sensor Settings
 """"""""""""""""""""""""
 
-.. function:: void setMode(mode mode)
+.. function:: void setMode(bool enable)
 
     Sets mode to run sensor in
 
-    :param mode: Mode to run sensor in
-
-    * ``EVNEnvSensor::mode::SLEEP`` (low-current sleep mode, measurement disabled)
-    * ``EVNEnvSensor::mode::NORMAL`` (measurement enabled)
+    :param enable: Whether measurement is enabled
 
 .. function:: void setSamplingRate(sampling sampling_temp, sampling sampling_hum, sampling sampling_pres)
     
@@ -153,12 +141,12 @@ Advanced Sensor Settings
     :param sampling_pres: Sampling rate for pressure
     :param sampling_hum: Sampling rate for humidity
 
-    * ``EVNEnvSensor::sampling::OFF`` (disables measurement)
-    * ``EVNEnvSensor::sampling::X1`` (1)
-    * ``EVNEnvSensor::sampling::X2`` (2)
-    * ``EVNEnvSensor::sampling::X4`` (4)
-    * ``EVNEnvSensor::sampling::X8`` (8)
-    * ``EVNEnvSensor::sampling::X16`` (16)
+    * ``ENV_SAMPLING_OFF`` (disables measurement)
+    * ``ENV_SAMPLING_X1`` (1)
+    * ``ENV_SAMPLING_X2`` (2)
+    * ``ENV_SAMPLING_X4`` (4)
+    * ``ENV_SAMPLING_X8`` (8)
+    * ``ENV_SAMPLING_X16`` (16)
 
 .. function:: void setFilterRate(filter filter)
 
@@ -166,11 +154,11 @@ Advanced Sensor Settings
 
     :param filter: Filter rate for pressure measurements
 
-    * ``EVNEnvSensor::filter::OFF`` (filter disabled)
-    * ``EVNEnvSensor::filter::X2`` (2)
-    * ``EVNEnvSensor::filter::X4`` (4)
-    * ``EVNEnvSensor::filter::X8`` (8)
-    * ``EVNEnvSensor::filter::X16`` (16)
+    * ``ENV_FILTER_OFF`` (filter disabled)
+    * ``ENV_FILTER_X2`` (2)
+    * ``ENV_FILTER_X4`` (4)
+    * ``ENV_FILTER_X8`` (8)
+    * ``ENV_FILTER_X16`` (16)
 
 .. function:: void setStandbyTime(standby standby_time)
 
@@ -178,12 +166,12 @@ Advanced Sensor Settings
 
     :param standby_time: Standby time between readings
 
-    * ``EVNEnvSensor::standby::MS_0_5`` (0.5ms)
-    * ``EVNEnvSensor::standby::MS_10`` (10ms)
-    * ``EVNEnvSensor::standby::MS_20`` (20ms)
-    * ``EVNEnvSensor::standby::MS_62_5`` (62.5ms)
-    * ``EVNEnvSensor::standby::MS_125`` (125ms)
-    * ``EVNEnvSensor::standby::MS_250`` (250ms)
-    * ``EVNEnvSensor::standby::MS_500`` (500ms)
-    * ``EVNEnvSensor::standby::MS_1000`` (1000ms)
+    * ``ENV_STANDBY_MS_0_5`` (0.5ms)
+    * ``ENV_STANDBY_MS_10`` (10ms)
+    * ``ENV_STANDBY_MS_20`` (20ms)
+    * ``ENV_STANDBY_MS_62_5`` (62.5ms)
+    * ``ENV_STANDBY_MS_125`` (125ms)
+    * ``ENV_STANDBY_MS_250`` (250ms)
+    * ``ENV_STANDBY_MS_500`` (500ms)
+    * ``ENV_STANDBY_MS_1000`` (1000ms)
 

--- a/docs/sensors/evnimusensor.rst
+++ b/docs/sensors/evnimusensor.rst
@@ -29,9 +29,12 @@ GND   GND         Ground (0V)
 Constructor
 -----------
 
-.. class:: EVNIMUSensor(uint8_t port, float gx_offset = 0, float gy_offset = 0, float gz_offset = 0, float ax_low = 0, float ax_high = 0, float ay_low = 0, float ay_high = 0, float az_low = 0, float az_high = 0)
+.. class:: EVNIMUSensor(uint8_t port, data_rate data_rate = IMU_HZ_92, accel_range accel_range = IMU_ACCEL_G_4, gyro_range gyro_range = IMU_GYRO_DPS_500, float gx_offset = 0, float gy_offset = 0, float gz_offset = 0, float ax_low = 0, float ax_high = 0, float ay_low = 0, float ay_high = 0, float az_low = 0, float az_high = 0)
 
     :param port: I2C port the sensor is connected to (1-16)
+    :param data_rate: Data rate of gyroscope and accelerometer measurements. Defaults to ``IMU_HZ_92``
+    :param accel_range: Range of accelerometer measurements. Defaults to ``IMU_ACCEL_G_4``
+    :param gyro_range: Range of gyroscope measurements. Defaults to ``IMU_GYRO_DPS_500``
     :param gx_offset: Gyroscope X-axis offset. Defaults to 0
     :param gy_offset: Gyroscope Y-axis offset. Defaults to 0
     :param gz_offset: Gyroscope Z-axis offset. Defaults to 0
@@ -188,27 +191,27 @@ However, the IMU Sensor Standard Peripheral can be mounted in many orientations,
 
     :param range: Range of accelerometer measurements
 
-    * ``EVNIMUSensor::accel_range::G_2`` (+-2g)
-    * ``EVNIMUSensor::accel_range::G_4`` (+-4g)
-    * ``EVNIMUSensor::accel_range::G_8`` (+-8g)
-    * ``EVNIMUSensor::accel_range::G_16`` (+-16g)
+    * ``IMU_ACCEL_G_2`` (+-2g)
+    * ``IMU_ACCEL_G_4`` (+-4g)
+    * ``IMU_ACCEL_G_8`` (+-8g)
+    * ``IMU_ACCEL_G_16`` (+-16g)
 
 .. function:: void setGyroRange(gyro_range range)
 
     :param range: Range of gyroscope measurements
 
-    * ``EVNIMUSensor::gyro_range::DPS_250`` (+-250DPS)
-    * ``EVNIMUSensor::gyro_range::DPS_500`` (+-500DPS)
-    * ``EVNIMUSensor::gyro_range::DPS_1000`` (+-1000DPS)
-    * ``EVNIMUSensor::gyro_range::DPS_2000`` (+-2000DPS)
+    * ``IMU_GYRO_DPS_250`` (+-250DPS)
+    * ``IMU_GYRO_DPS_500`` (+-500DPS)
+    * ``IMU_GYRO_DPS_1000`` (+-1000DPS)
+    * ``IMU_GYRO_DPS_2000`` (+-2000DPS)
 
 .. function:: void setDataRate(data_rate data_rate)
 
     :param data_rate: Data rate of gyroscope and accelerometer measurements
 
-    * ``EVNIMUSensor::data_rate::HZ_5`` (5 Hz)
-    * ``EVNIMUSensor::data_rate::HZ_10`` (10 Hz)
-    * ``EVNIMUSensor::data_rate::HZ_20`` (20 Hz)
-    * ``EVNIMUSensor::data_rate::HZ_41`` (41 Hz)
-    * ``EVNIMUSensor::data_rate::HZ_92`` (92 Hz)
-    * ``EVNIMUSensor::data_rate::HZ_184`` (184 Hz)
+    * ``IMU_HZ_5`` (5 Hz)
+    * ``IMU_HZ_10`` (10 Hz)
+    * ``IMU_HZ_20`` (20 Hz)
+    * ``IMU_HZ_41`` (41 Hz)
+    * ``IMU_HZ_92`` (92 Hz)
+    * ``IMU_HZ_184`` (184 Hz)

--- a/examples/1. Basics/b) Actuators/moveDrivebase/moveDrivebase.ino
+++ b/examples/1. Basics/b) Actuators/moveDrivebase/moveDrivebase.ino
@@ -16,8 +16,8 @@ EVNAlpha board;
 //however, you can set link_movement to true to use the button as an enable/disable switch for motors and servos
 //to try this out, uncomment line 12 and comment line 10
 
-EVNMotor left(MOTOR_PORT_LEFT, EV3_LARGE);  //motor type can be NXT_LARGE, EV3_LARGE or MOTOR_CUSTOM
-EVNMotor right(MOTOR_PORT_RIGHT, EV3_LARGE);  //motor type can be NXT_LARGE, EV3_LARGE or MOTOR_CUSTOM
+EVNMotor left(MOTOR_PORT_LEFT, EV3_LARGE);  //motor type can be NXT_LARGE, EV3_LARGE or CUSTOM_MOTOR
+EVNMotor right(MOTOR_PORT_RIGHT, EV3_LARGE);  //motor type can be NXT_LARGE, EV3_LARGE or CUSTOM_MOTOR
 EVNDrivebase db(62.4, 170, &left, &right);
 
 void setup1()

--- a/examples/1. Basics/b) Actuators/moveDrivebase/moveDrivebase.ino
+++ b/examples/1. Basics/b) Actuators/moveDrivebase/moveDrivebase.ino
@@ -16,8 +16,8 @@ EVNAlpha board;
 //however, you can set link_movement to true to use the button as an enable/disable switch for motors and servos
 //to try this out, uncomment line 12 and comment line 10
 
-EVNMotor left(MOTOR_PORT_LEFT, EV3_LARGE);  //motor type can be NXT_LARGE, EV3_LARGE or CUSTOM_MOTOR
-EVNMotor right(MOTOR_PORT_RIGHT, EV3_LARGE);  //motor type can be NXT_LARGE, EV3_LARGE or CUSTOM_MOTOR
+EVNMotor left(MOTOR_PORT_LEFT, EV3_LARGE);  //motor type can be NXT_LARGE, EV3_LARGE, EV3_MED or CUSTOM_MOTOR
+EVNMotor right(MOTOR_PORT_RIGHT, EV3_LARGE);  //motor type can be NXT_LARGE, EV3_LARGE, EV3_MED or CUSTOM_MOTOR
 EVNDrivebase db(62.4, 170, &left, &right);
 
 void setup1()

--- a/examples/1. Basics/b) Actuators/moveMotor/moveMotor.ino
+++ b/examples/1. Basics/b) Actuators/moveMotor/moveMotor.ino
@@ -15,7 +15,7 @@ EVNAlpha board;
 //however, you can set link_movement to true to use the button as an enable/disable switch for motors and servos
 //to try this out, uncomment line 12 and comment line 10
 
-EVNMotor motor(MOTOR_PORT, EV3_MED);  //motor type can be NXT_LARGE, EV3_LARGE or CUSTOM_MOTOR
+EVNMotor motor(MOTOR_PORT, EV3_MED);  //motor type can be NXT_LARGE, EV3_LARGE, EV3_MED or CUSTOM_MOTOR
 
 void setup1()
 {
@@ -36,7 +36,7 @@ void loop()
 		//for quick reference, 1 RPM (revolution per minute) = 6 DPS (degrees per second)
 
 		motor.runTime(300, 2000); 	//run motor at 300DPS for 2s
-		motor.runAngle(400, -360);	//run motor at 400DPS for -360deg (runAngle(-400, 360) produces the same effect)
+		motor.runAngle(400, -360);	//run motor at -400DPS for -360deg
 		motor.runSpeed(-600);    	//run motor at -600DPS until new command is given
 		delay(6000);           	//continue running for 6 seconds
 	}

--- a/examples/1. Basics/b) Actuators/moveMotor/moveMotor.ino
+++ b/examples/1. Basics/b) Actuators/moveMotor/moveMotor.ino
@@ -15,7 +15,7 @@ EVNAlpha board;
 //however, you can set link_movement to true to use the button as an enable/disable switch for motors and servos
 //to try this out, uncomment line 12 and comment line 10
 
-EVNMotor motor(MOTOR_PORT, EV3_MED);  //motor type can be NXT_LARGE, EV3_LARGE or MOTOR_CUSTOM
+EVNMotor motor(MOTOR_PORT, EV3_MED);  //motor type can be NXT_LARGE, EV3_LARGE or CUSTOM_MOTOR
 
 void setup1()
 {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EVN
-version=1.1.3
+version=1.2.0
 author=Heng Teng Yi <tengyi.maker@gmail.com>
 maintainer=Heng Teng Yi <tengyi.maker@gmail.com>
 sentence=Software libraries for EVN Alpha.

--- a/src/actuators/EVNMotor.cpp
+++ b/src/actuators/EVNMotor.cpp
@@ -9,13 +9,13 @@ volatile drivebase_state_t* EVNDrivebase::dbArgs[] = { };
 volatile bool EVNDrivebase::dbs_started[] = { };
 volatile bool EVNDrivebase::timerisr_enabled = false;
 
-EVNMotor::EVNMotor(uint8_t port, uint8_t motortype, uint8_t motor_dir, uint8_t enc_dir)
+EVNMotor::EVNMotor(uint8_t port, uint8_t motor_type, uint8_t motor_dir, uint8_t enc_dir)
 {
 	// clean inputs
 	motor_dir = constrain(motor_dir, 0, 1);
 	enc_dir = constrain(enc_dir, 0, 1);
 	_pid_control.port = constrain(port, 1, 4);
-	motortype = constrain(motortype, 0, 3);
+	motor_type = constrain(motor_type, 0, 3);
 
 	// set pins
 	switch (_pid_control.port)
@@ -67,9 +67,9 @@ EVNMotor::EVNMotor(uint8_t port, uint8_t motortype, uint8_t motor_dir, uint8_t e
 	}
 
 	// configure settings according to motor type
-	_pid_control.motor_type = motortype;
+	_pid_control.motor_type = motor_type;
 
-	switch (motortype)
+	switch (motor_type)
 	{
 	case EV3_LARGE:
 		_pid_control.max_rpm = EV3_LARGE_MAX_RPM;
@@ -315,7 +315,7 @@ void EVNMotor::runAngle(float dps, float degrees, uint8_t stop_action, bool wait
 	if (dps == 0 || degrees == 0)
 		return;
 
-	if ((dps < 0) || (degrees < 0))
+	if (dps < 0 || degrees < 0)
 	{
 		dps = -fabs(dps);
 		degrees = -fabs(degrees);
@@ -757,7 +757,7 @@ void EVNDrivebase::straight(float speed, float distance, uint8_t stop_action, bo
 	if (distance == 0 || speed == 0)
 		return;
 
-	if ((distance < 0) || (speed < 0))
+	if (distance < 0 || speed < 0)
 	{
 		distance = -fabs(distance);
 		speed = -fabs(speed);
@@ -810,7 +810,7 @@ void EVNDrivebase::curveTurnRate(float speed, float turn_rate, float angle, uint
 	if (turn_rate == 0 || angle == 0)
 		return;
 
-	if ((angle < 0) || (turn_rate < 0))
+	if (angle < 0 || turn_rate < 0)
 	{
 		angle = -fabs(angle);
 		turn_rate = -fabs(turn_rate);

--- a/src/actuators/EVNMotor.cpp
+++ b/src/actuators/EVNMotor.cpp
@@ -12,13 +12,13 @@ volatile bool EVNDrivebase::timerisr_enabled = false;
 EVNMotor::EVNMotor(uint8_t port, uint8_t motortype, uint8_t motor_dir, uint8_t enc_dir)
 {
 	// clean inputs
-	uint8_t motor_dirc = constrain(motor_dir, 0, 1);
-	uint8_t enc_dirc = constrain(enc_dir, 0, 1);
-	uint8_t portc = constrain(port, 1, 4);
-	uint8_t motortypec = constrain(motortype, 0, 3);
+	motor_dir = constrain(motor_dir, 0, 1);
+	enc_dir = constrain(enc_dir, 0, 1);
+	_pid_control.port = constrain(port, 1, 4);
+	motortype = constrain(motortype, 0, 3);
 
 	// set pins
-	switch (portc)
+	switch (_pid_control.port)
 	{
 	case 1:
 		_pid_control.motora = PIN_MOTOR1_OUTA;
@@ -49,7 +49,7 @@ EVNMotor::EVNMotor(uint8_t port, uint8_t motortype, uint8_t motor_dir, uint8_t e
 	// swap pins if needed
 	uint8_t pin = 0;
 
-	if (motor_dirc == REVERSE)
+	if (motor_dir == REVERSE)
 	{
 		pin = _pid_control.motora;
 		_pid_control.motora = _pid_control.motorb;
@@ -59,7 +59,7 @@ EVNMotor::EVNMotor(uint8_t port, uint8_t motortype, uint8_t motor_dir, uint8_t e
 		_encoder.encb = pin;
 	}
 
-	if (enc_dirc == REVERSE)
+	if (enc_dir == REVERSE)
 	{
 		pin = _encoder.enca;
 		_encoder.enca = _encoder.encb;
@@ -67,10 +67,9 @@ EVNMotor::EVNMotor(uint8_t port, uint8_t motortype, uint8_t motor_dir, uint8_t e
 	}
 
 	// configure settings according to motor type
+	_pid_control.motor_type = motortype;
 
-	_pid_control.motor_type = motortypec;
-
-	switch (motortypec)
+	switch (motortype)
 	{
 	case EV3_LARGE:
 		_pid_control.max_rpm = EV3_LARGE_MAX_RPM;
@@ -105,6 +104,13 @@ EVNMotor::EVNMotor(uint8_t port, uint8_t motortype, uint8_t motor_dir, uint8_t e
 
 void EVNMotor::begin() volatile
 {
+	EVNCoreSync0.begin();
+
+	if (timerisr_enabled)
+		EVNCoreSync0.core0_enter();
+	else
+		EVNCoreSync0.core0_enter_force();
+
 	//configure pins
 	analogWriteFreq(PWM_FREQ);
 	analogWriteRange(PWM_MAX_VAL);
@@ -115,6 +121,8 @@ void EVNMotor::begin() volatile
 
 	//attach pin change interrupts (encoder) and timer interrupt (PID control)
 	attach_interrupts(&_encoder, &_pid_control);
+
+	EVNCoreSync0.core0_exit();
 }
 
 void EVNMotor::setPID(float p, float i, float d) volatile
@@ -250,14 +258,14 @@ void EVNMotor::runPWM(float duty_cycle_pct) volatile
 	if (!timerisr_enabled) return;
 	EVNCoreSync0.core0_enter();
 
-	float duty_cycle_pctc = constrain(duty_cycle_pct, -100, 100) / 100;
+	duty_cycle_pct = constrain(duty_cycle_pct, -100, 100) / 100;
 
 	_pid_control.run_pwm = true;
 	_pid_control.run_speed = false;
 	_pid_control.run_time = false;
 	_pid_control.run_pos = false;
 
-	runPWM_static(&_pid_control, duty_cycle_pctc);
+	runPWM_static(&_pid_control, duty_cycle_pct);
 
 	EVNCoreSync0.core0_exit();
 }
@@ -304,23 +312,28 @@ void EVNMotor::runPosition(float dps, float position, uint8_t stop_action, bool 
 
 void EVNMotor::runAngle(float dps, float degrees, uint8_t stop_action, bool wait) volatile
 {
-	float degreesc = degrees;
-	if (dps < 0 && degreesc > 0)
-		degreesc = -degreesc;
+	if (dps == 0 || degrees == 0)
+		return;
 
-	this->runPosition(dps, this->getTargetPosition() + degreesc, stop_action, wait);
+	if ((dps < 0) || (degrees < 0))
+	{
+		dps = -fabs(dps);
+		degrees = -fabs(degrees);
+	}
+
+	this->runPosition(dps, this->getTargetPosition() + degrees, stop_action, wait);
 }
 
 void EVNMotor::runHeading(float dps, float heading, uint8_t stop_action, bool wait) volatile
 {
-	float target_heading = constrain(heading, 0, 360);
-	float degreesc = target_heading - this->getTargetHeading();
-	if (degreesc > 180)
-		degreesc -= 360;
-	if (degreesc < -180)
-		degreesc += 360;
+	heading = constrain(heading, 0, 360);
+	float degrees = heading - this->getTargetHeading();
+	if (degrees > 180)
+		degrees -= 360;
+	if (degrees < -180)
+		degrees += 360;
 
-	this->runPosition(dps, this->getTargetPosition() + degreesc, stop_action, wait);
+	this->runAngle(dps, degrees, stop_action, wait);
 }
 
 void EVNMotor::runTime(float dps, uint32_t time_ms, uint8_t stop_action, bool wait) volatile
@@ -519,7 +532,15 @@ void EVNDrivebase::setTurnRateDecel(float turn_rate_decel) volatile
 
 void EVNDrivebase::begin() volatile
 {
+	EVNCoreSync0.begin();
+	if (timerisr_enabled || EVNMotor::timerisr_enabled)
+		EVNCoreSync0.core0_enter();
+	else
+		EVNCoreSync0.core0_enter_force();
+
 	attach_db_interrupt(&db);
+
+	EVNCoreSync0.core0_exit();
 }
 
 float EVNDrivebase::getDistance() volatile
@@ -675,41 +696,41 @@ void EVNDrivebase::drive(float speed, float turn_rate) volatile
 
 void EVNDrivebase::drivePct(float speed_outer_pct, float turn_rate_pct) volatile
 {
-	float turn_rate_pctc = constrain(turn_rate_pct, -100, 100) / 100;
-	float speed_outer_pctc = constrain(speed_outer_pct, -100, 100) / 100;
-	float speed_inner_pctc = speed_outer_pctc * (1 - 2 * fabs(turn_rate_pctc));
-	float speed = (speed_outer_pctc + speed_inner_pctc) / 2 * db.max_speed;
+	turn_rate_pct = constrain(turn_rate_pct, -100, 100) / 100;
+	speed_outer_pct = constrain(speed_outer_pct, -100, 100) / 100;
+	float speed_inner_pct = speed_outer_pct * (1 - 2 * fabs(turn_rate_pct));
+	float speed = (speed_outer_pct + speed_inner_pct) / 2 * db.max_speed;
 
 	//drive straight
-	if (turn_rate_pctc == 0)
+	if (turn_rate_pct == 0)
 		this->drive(speed, 0);
 
 	//turn on the spot
-	else if (fabs(turn_rate_pctc) == 1)
-		this->drive(0, fabs(speed_outer_pctc) * db.max_turn_rate * turn_rate_pctc);
+	else if (fabs(turn_rate_pct) == 1)
+		this->drive(0, fabs(speed_outer_pct) * db.max_turn_rate * turn_rate_pct);
 
 	//centre of turning radius between wheels
-	else if (turn_rate_pctc >= 0.5)
-		this->driveRadius(speed, db.axle_track * (1 - turn_rate_pctc));
+	else if (turn_rate_pct >= 0.5)
+		this->driveRadius(speed, db.axle_track * (1 - turn_rate_pct));
 
-	else if (turn_rate_pctc <= -0.5)
-		this->driveRadius(speed, -db.axle_track * (1 + turn_rate_pctc));
+	else if (turn_rate_pct <= -0.5)
+		this->driveRadius(speed, -db.axle_track * (1 + turn_rate_pct));
 
 	//centre of turning radius outside of wheels
 	else
-		this->driveRadius(speed, db.axle_track * 0.25 / turn_rate_pctc);
+		this->driveRadius(speed, db.axle_track * 0.25 / turn_rate_pct);
 }
 
 void EVNDrivebase::driveTurnRate(float speed, float turn_rate) volatile
 {
-	float turn_ratec = clean_input_turn_rate(turn_rate);
-	float speedc = clean_input_speed(speed, turn_ratec);
+	turn_rate = clean_input_turn_rate(turn_rate);
+	speed = clean_input_speed(speed, turn_rate);
 
 	if (!timerisr_enabled) return;
 	EVNCoreSync0.core0_enter();
 
-	db.target_speed = speedc;
-	db.target_turn_rate = turn_ratec;
+	db.target_speed = speed;
+	db.target_turn_rate = turn_rate;
 	db.drive = true;
 	db.drive_position = false;
 
@@ -718,34 +739,36 @@ void EVNDrivebase::driveTurnRate(float speed, float turn_rate) volatile
 
 void EVNDrivebase::driveRadius(float speed, float radius) volatile
 {
-	float speedc = speed;
-	float turn_ratec = radius_to_turn_rate(speed, radius);
+	float turn_rate = radius_to_turn_rate(speed, radius);
 	if (radius == 0)
-		speedc = 0;
+		speed = 0;
 
-	float scale = scaling_factor_for_maintaining_radius(speedc, turn_ratec);
-	turn_ratec *= scale;
-	speedc *= scale;
+	float scale = scaling_factor_for_maintaining_radius(speed, turn_rate);
+	turn_rate *= scale;
+	speed *= scale;
 
-	this->driveTurnRate(speedc, turn_ratec);
+	this->driveTurnRate(speed, turn_rate);
 }
 
 void EVNDrivebase::straight(float speed, float distance, uint8_t stop_action, bool wait) volatile
 {
-	float speedc = clean_input_speed(speed, 0);
+	speed = clean_input_speed(speed, 0);
 
-	if (distance == 0 || speedc == 0)
+	if (distance == 0 || speed == 0)
 		return;
 
-	if ((distance > 0) != (speedc > 0))
-		speedc = -speedc;
+	if ((distance < 0) || (speed < 0))
+	{
+		distance = -fabs(distance);
+		speed = -fabs(speed);
+	}
 
 	if (!timerisr_enabled) return;
 	EVNCoreSync0.core0_enter();
 
 	db.end_angle = db.target_angle;
 	db.end_distance = db.target_distance + distance;
-	db.target_speed = speedc;
+	db.target_speed = speed;
 	db.target_turn_rate = 0;
 	db.stop_action = clean_input_stop_action(stop_action);
 	db.drive = true;
@@ -767,39 +790,41 @@ void EVNDrivebase::curve(float speed, float radius, float angle, uint8_t stop_ac
 
 void EVNDrivebase::curveRadius(float speed, float radius, float angle, uint8_t stop_action, bool wait) volatile
 {
-	float speedc = speed;
-	float turn_ratec = radius_to_turn_rate(speedc, radius);
+	float turn_rate = radius_to_turn_rate(speed, radius);
 
 	if (radius == 0)
-		speedc = 0;
+		speed = 0;
 
-	float scale = scaling_factor_for_maintaining_radius(speedc, turn_ratec);
-	turn_ratec *= scale;
-	speedc *= scale;
+	float scale = scaling_factor_for_maintaining_radius(speed, turn_rate);
+	turn_rate *= scale;
+	speed *= scale;
 
-	this->curveTurnRate(speedc, turn_ratec, angle, stop_action, wait);
+	this->curveTurnRate(speed, turn_rate, angle, stop_action, wait);
 }
 
 void EVNDrivebase::curveTurnRate(float speed, float turn_rate, float angle, uint8_t stop_action, bool wait) volatile
 {
-	float turn_ratec = clean_input_turn_rate(turn_rate);
-	float speedc = clean_input_speed(speed, turn_ratec);
+	turn_rate = clean_input_turn_rate(turn_rate);
+	speed = clean_input_speed(speed, turn_rate);
 
-	if (turn_ratec == 0 || angle == 0)
+	if (turn_rate == 0 || angle == 0)
 		return;
 
-	if ((angle < 0) != (turn_ratec < 0))
-		angle = -angle;
+	if ((angle < 0) || (turn_rate < 0))
+	{
+		angle = -fabs(angle);
+		turn_rate = -fabs(turn_rate);
+	}
 
-	float distance = angle / turn_ratec * speedc;
+	float distance = angle / turn_rate * speed;
 
 	if (!timerisr_enabled) return;
 	EVNCoreSync0.core0_enter();
 
 	db.end_angle = db.target_angle + angle;
 	db.end_distance = db.target_distance + distance;
-	db.target_speed = speedc;
-	db.target_turn_rate = turn_ratec;
+	db.target_speed = speed;
+	db.target_turn_rate = turn_rate;
 	db.stop_action = clean_input_stop_action(stop_action);
 	db.drive = true;
 	db.drive_position = true;
@@ -825,8 +850,8 @@ void EVNDrivebase::turnDegrees(float turn_rate, float degrees, uint8_t stop_acti
 
 void EVNDrivebase::turnHeading(float turn_rate, float heading, uint8_t stop_action, bool wait) volatile
 {
-	float target_heading = constrain(heading, 0, 360);
-	float turn_angle = target_heading - getTargetHeading();
+	heading = constrain(heading, 0, 360);
+	float turn_angle = heading - getTargetHeading();
 	if (turn_angle > 180)
 		turn_angle -= 360;
 	if (turn_angle < -180)

--- a/src/actuators/EVNMotor.h
+++ b/src/actuators/EVNMotor.h
@@ -153,7 +153,7 @@ public:
 	friend class EVNDrivebase;
 	friend class EVNOmniDrivebaseBasic;
 
-	EVNMotor(uint8_t port, uint8_t motortype = EV3_LARGE, uint8_t motor_dir = DIRECT, uint8_t enc_dir = DIRECT);
+	EVNMotor(uint8_t port, uint8_t motor_type = EV3_LARGE, uint8_t motor_dir = DIRECT, uint8_t enc_dir = DIRECT);
 	void begin() volatile;
 	float getPosition() volatile;
 	float getHeading() volatile;

--- a/src/actuators/EVNMotor.h
+++ b/src/actuators/EVNMotor.h
@@ -54,6 +54,7 @@ typedef struct
 typedef struct
 {
 	//MOTOR CHARACTERISTICS
+	uint8_t port;
 	uint8_t motor_type;
 	uint8_t motora;
 	uint8_t motorb;
@@ -512,10 +513,9 @@ protected:
 	//also adds timer interrupt shared by all ports (if not already added)
 	static void attach_interrupts(volatile encoder_state_t* encoderArg, volatile pid_control_t* pidArg)
 	{
-		switch (encoderArg->enca)
+		switch (pidArg->port)
 		{
-		case PIN_MOTOR1_ENCA:
-		case PIN_MOTOR1_ENCB:
+		case 1:
 			if (!ports_started[0])
 			{
 				encoderArgs[0] = encoderArg;
@@ -526,8 +526,7 @@ protected:
 			}
 			break;
 
-		case PIN_MOTOR2_ENCA:
-		case PIN_MOTOR2_ENCB:
+		case 2:
 			if (!ports_started[1])
 			{
 				encoderArgs[1] = encoderArg;
@@ -538,8 +537,7 @@ protected:
 			}
 			break;
 
-		case PIN_MOTOR3_ENCA:
-		case PIN_MOTOR3_ENCB:
+		case 3:
 			if (!ports_started[2])
 			{
 				encoderArgs[2] = encoderArg;
@@ -550,8 +548,7 @@ protected:
 			}
 			break;
 
-		case PIN_MOTOR4_ENCA:
-		case PIN_MOTOR4_ENCB:
+		case 4:
 			if (!ports_started[3])
 			{
 				encoderArgs[3] = encoderArg;
@@ -565,8 +562,6 @@ protected:
 
 		if (!timerisr_enabled)
 		{
-			EVNCoreSync0.begin();
-
 			if (rp2040.cpuid() == 0)
 				alarm_pool_add_repeating_timer_us(EVNISRTimer0.sharedAlarmPool(), PID_TIMER_INTERVAL_US, timerisr, nullptr, &EVNISRTimer0.sharedISRTimer(3));
 			else
@@ -772,8 +767,6 @@ private:
 				cancel_repeating_timer(&EVNISRTimer1.sharedISRTimer(3));
 			}
 
-			EVNCoreSync0.begin();
-
 			if (rp2040.cpuid() == 0)
 				alarm_pool_add_repeating_timer_us(EVNISRTimer0.sharedAlarmPool(), PID_TIMER_INTERVAL_US, timerisr, nullptr, &EVNISRTimer0.sharedISRTimer(4));
 			else
@@ -791,7 +784,9 @@ private:
 			for (int i = 0; i < MAX_DB_OBJECTS; i++)
 			{
 				if (dbs_started[i])
-					pid_update(dbArgs[i]);
+					if (EVNMotor::ports_started[dbArgs[i]->motor_left->_pid_control.port - 1]
+						&& EVNMotor::ports_started[dbArgs[i]->motor_right->_pid_control.port - 1])
+						pid_update(dbArgs[i]);
 			}
 
 			for (int i = 0; i < EVNMotor::MAX_MOTOR_OBJECTS; i++)

--- a/src/actuators/EVNServo.h
+++ b/src/actuators/EVNServo.h
@@ -151,6 +151,7 @@ protected:
 class EVNContinuousServo : public EVNServoBase
 {
     friend class EVNServo;
+    using EVNServoBase::EVNServoBase;
 
 public:
     void begin() volatile;

--- a/src/helper/EVNCoreSync.h
+++ b/src/helper/EVNCoreSync.h
@@ -51,6 +51,15 @@ public:
         mutex_enter_blocking(&_mutex);
     };
 
+    void core0_enter_force()
+    {
+        //grabs mutex without ensuring timerisr has executed once
+
+        if (!_started) return;
+
+        mutex_enter_blocking(&_mutex);
+    };
+
     void core0_exit()
     {
         //WARNING: assumes that core0_enter has been called

--- a/src/sensors/EVNColourSensor.h
+++ b/src/sensors/EVNColourSensor.h
@@ -83,7 +83,7 @@ public:
         X64 = 0x03
     };
 
-    EVNColourSensor(uint8_t port, uint8_t integration_cycles = 1, gain gain = gain::X16) : EVNI2CDevice(port)
+    EVNColourSensor(uint8_t port, uint8_t integration_cycles = 1, gain gain = COLOUR_GAIN_X16) : EVNI2CDevice(port)
     {
         _addr = I2C_ADDR;
         _gain = gain;

--- a/src/sensors/EVNColourSensor.h
+++ b/src/sensors/EVNColourSensor.h
@@ -6,6 +6,11 @@
 #include "../EVNAlpha.h"
 #include "../helper/EVNI2CDevice.h"
 
+#define COLOUR_GAIN_X1  (EVNColourSensor::gain::X1)
+#define COLOUR_GAIN_X4  (EVNColourSensor::gain::X4)
+#define COLOUR_GAIN_X16 (EVNColourSensor::gain::X16)
+#define COLOUR_GAIN_X60 (EVNColourSensor::gain::X60)
+
 struct evn_col
 {
     uint16_t red;

--- a/src/sensors/EVNCompassSensor.h
+++ b/src/sensors/EVNCompassSensor.h
@@ -267,9 +267,9 @@ public:
                 value = read8(hmc_reg::MODE);
                 value &= 0b11111100;
                 if (enable)
-                    value |= hmc_mode::CONTINUOUS;
+                    value |= (uint8_t)hmc_mode::CONTINUOUS;
                 else
-                    value |= hmc_mode::STANDBY;
+                    value |= (uint8_t)hmc_mode::STANDBY;
                 write8(hmc_reg::MODE, value);
             }
             else
@@ -278,9 +278,9 @@ public:
                 value = read8(qmc_reg::CONFIG);
                 value &= 0b11111100;
                 if (enable)
-                    value |= qmc_mode::CONTINUOUS;
+                    value |= (uint8_t)qmc_mode::CONTINUOUS;
                 else
-                    value |= qmc_mode::STANDBY;
+                    value |= (uint8_t)qmc_mode::STANDBY;
                 write8(qmc_reg::CONFIG, value);
             }
         }

--- a/src/sensors/EVNEnvSensor.h
+++ b/src/sensors/EVNEnvSensor.h
@@ -19,14 +19,14 @@
 #define ENV_FILTER_X8       (EVNEnvSensor::filter::X8)
 #define ENV_FILTER_X16      (EVNEnvSensor::filter::X16)
 
-#define ENV_STANDBY_MS_0_5  (EVNEnvSensor::standby::MS_MS_0_5)
-#define ENV_STANDBY_MS_10   (EVNEnvSensor::standby::MS_MS_10)
-#define ENV_STANDBY_MS_20   (EVNEnvSensor::standby::MS_MS_20)
-#define ENV_STANDBY_MS_62_5 (EVNEnvSensor::standby::MS_MS_62_5)
-#define ENV_STANDBY_MS_125  (EVNEnvSensor::standby::MS_MS_125)
-#define ENV_STANDBY_MS_250  (EVNEnvSensor::standby::MS_MS_250)
-#define ENV_STANDBY_MS_500  (EVNEnvSensor::standby::MS_MS_500)
-#define ENV_STANDBY_MS_1000 (EVNEnvSensor::standby::MS_MS_1000)
+#define ENV_STANDBY_MS_0_5  (EVNEnvSensor::standby::MS_0_5)
+#define ENV_STANDBY_MS_10   (EVNEnvSensor::standby::MS_10)
+#define ENV_STANDBY_MS_20   (EVNEnvSensor::standby::MS_20)
+#define ENV_STANDBY_MS_62_5 (EVNEnvSensor::standby::MS_62_5)
+#define ENV_STANDBY_MS_125  (EVNEnvSensor::standby::MS_125)
+#define ENV_STANDBY_MS_250  (EVNEnvSensor::standby::MS_250)
+#define ENV_STANDBY_MS_500  (EVNEnvSensor::standby::MS_500)
+#define ENV_STANDBY_MS_1000 (EVNEnvSensor::standby::MS_1000)
 
 struct evn_env
 {
@@ -141,7 +141,7 @@ public:
         _addr = I2C_ADDR;
 
         _sampling_temp = sampling_temp;
-        _sampling_press = sampling_pres;
+        _sampling_pres = sampling_pres;
         _sampling_hum = sampling_hum;
         _filter = filter;
         _standby = standby;

--- a/src/sensors/EVNEnvSensor.h
+++ b/src/sensors/EVNEnvSensor.h
@@ -6,6 +6,28 @@
 #include "../EVNAlpha.h"
 #include "../helper/EVNI2CDevice.h"
 
+#define ENV_SAMPLING_OFF    (EVNEnvSensor::sampling::OFF)
+#define ENV_SAMPLING_X1     (EVNEnvSensor::sampling::X1)
+#define ENV_SAMPLING_X2     (EVNEnvSensor::sampling::X2)
+#define ENV_SAMPLING_X4     (EVNEnvSensor::sampling::X4)
+#define ENV_SAMPLING_X8     (EVNEnvSensor::sampling::X8)
+#define ENV_SAMPLING_X16    (EVNEnvSensor::sampling::X16)
+
+#define ENV_FILTER_OFF      (EVNEnvSensor::filter::OFF)
+#define ENV_FILTER_X2       (EVNEnvSensor::filter::X2)
+#define ENV_FILTER_X4       (EVNEnvSensor::filter::X4)
+#define ENV_FILTER_X8       (EVNEnvSensor::filter::X8)
+#define ENV_FILTER_X16      (EVNEnvSensor::filter::X16)
+
+#define ENV_STANDBY_MS_0_5  (EVNEnvSensor::standby::MS_MS_0_5)
+#define ENV_STANDBY_MS_10   (EVNEnvSensor::standby::MS_MS_10)
+#define ENV_STANDBY_MS_20   (EVNEnvSensor::standby::MS_MS_20)
+#define ENV_STANDBY_MS_62_5 (EVNEnvSensor::standby::MS_MS_62_5)
+#define ENV_STANDBY_MS_125  (EVNEnvSensor::standby::MS_MS_125)
+#define ENV_STANDBY_MS_250  (EVNEnvSensor::standby::MS_MS_250)
+#define ENV_STANDBY_MS_500  (EVNEnvSensor::standby::MS_MS_500)
+#define ENV_STANDBY_MS_1000 (EVNEnvSensor::standby::MS_MS_1000)
+
 struct evn_env
 {
     float pressure;
@@ -114,12 +136,15 @@ public:
         MS_1000 = 0x05,
     };
 
-    //settings are not exposed in this constructor because there are too many
-    //use set functions instead
-
-    EVNEnvSensor(uint8_t port) : EVNI2CDevice(port)
+    EVNEnvSensor(uint8_t port, sampling sampling_temp = ENV_SAMPLING_X1, sampling sampling_pres = ENV_SAMPLING_X1, sampling sampling_hum = ENV_SAMPLING_X1, filter filter = ENV_FILTER_OFF, standby standby = ENV_STANDBY_MS_0_5) : EVNI2CDevice(port)
     {
         _addr = I2C_ADDR;
+
+        _sampling_temp = sampling_temp;
+        _sampling_press = sampling_pres;
+        _sampling_hum = sampling_hum;
+        _filter = filter;
+        _standby = standby;
     };
 
     bool begin()
@@ -169,20 +194,22 @@ public:
 
         setSamplingRate(_sampling_temp, _sampling_hum, _sampling_pres);
         setFilterRate(_filter);
-        setStandbyTime(_standby_time);
-        setMode(_mode);
+        setStandbyTime(_standby);
+        setMode(true);
 
         _last_reading_us = micros();
 
         return _sensor_started;
     };
 
-    void setMode(mode mode)
+    void setMode(bool enable)
     {
         uint8_t value = read8((uint8_t)reg::CTRL_MEAS);
         value &= 0b11111100;
-        write8((uint8_t)reg::CTRL_MEAS, value | (uint8_t)mode);
-        _mode = mode;
+        if (enable)
+            write8((uint8_t)reg::CTRL_MEAS, value | (uint8_t)mode::NORMAL);
+        else
+            write8((uint8_t)reg::CTRL_MEAS, value | (uint8_t)mode::SLEEP);
     };
 
     void setSamplingRate(sampling sampling_temp, sampling sampling_hum, sampling sampling_pres)
@@ -241,9 +268,9 @@ public:
         _filter = filter;
     };
 
-    void setStandbyTime(standby standby_time)
+    void setStandbyTime(standby standby)
     {
-        switch (standby_time)
+        switch (standby)
         {
         case standby::MS_0_5:
             _standby_time_us = 500;
@@ -285,12 +312,12 @@ public:
         //write setting
         uint8_t value2 = read8((uint8_t)reg::CONFIG);
         value2 &= 0b00011111;
-        write8((uint8_t)reg::CONFIG, value2 | ((uint8_t)standby_time << 5));
+        write8((uint8_t)reg::CONFIG, value2 | ((uint8_t)standby << 5));
 
         //write original mode
         write8((uint8_t)reg::CTRL_MEAS, value1);
 
-        _standby_time = standby_time;
+        _standby = standby;
     };
 
     evn_env readAll(bool blocking = true)
@@ -493,12 +520,11 @@ private:
     uint32_t _standby_time_us;
     uint32_t _last_reading_us;
 
-    mode _mode = mode::NORMAL;
-    sampling _sampling_temp = sampling::X1;
-    sampling _sampling_pres = sampling::X1;
-    sampling _sampling_hum = sampling::X1;
-    filter _filter = filter::OFF;
-    standby _standby_time = standby::MS_0_5;
+    sampling _sampling_temp;
+    sampling _sampling_pres;
+    sampling _sampling_hum;
+    filter _filter;
+    standby _standby;
 };
 
 #endif

--- a/src/sensors/EVNGestureSensor.h
+++ b/src/sensors/EVNGestureSensor.h
@@ -12,6 +12,45 @@
 #define GESTURE_LEFT    3
 #define GESTURE_RIGHT   4
 
+#define GESTURE_FIFO_DATASETS_1     (EVNGestureSensor::gesture_fifo::DATASETS_1)
+#define GESTURE_FIFO_DATASETS_4     (EVNGestureSensor::gesture_fifo::DATASETS_4)
+#define GESTURE_FIFO_DATASETS_8     (EVNGestureSensor::gesture_fifo::DATASETS_8)
+#define GESTURE_FIFO_DATASETS_16    (EVNGestureSensor::gesture_fifo::DATASETS_16)
+
+#define GESTURE_LED_MA_100          (EVNGestureSensor::led_curr::GESTURE_MA_100)
+#define GESTURE_LED_MA_50           (EVNGestureSensor::led_curr::GESTURE_MA_50)
+#define GESTURE_LED_MA_25           (EVNGestureSensor::led_curr::GESTURE_MA_25)
+#define GESTURE_LED_MA_12_5         (EVNGestureSensor::led_curr::GESTURE_MA_12_5)
+
+#define GESTURE_LED_X1              (EVNGestureSensor::led_boost::X1)
+#define GESTURE_LED_X1_5            (EVNGestureSensor::led_boost::X1_5)
+#define GESTURE_LED_X2              (EVNGestureSensor::led_boost::X2)
+#define GESTURE_LED_X3              (EVNGestureSensor::led_boost::X3)
+
+#define GESTURE_COL_GAIN_X1         (EVNGestureSensor::colour_gain::X1)
+#define GESTURE_COL_GAIN_X4         (EVNGestureSensor::colour_gain::X4)
+#define GESTURE_COL_GAIN_X16        (EVNGestureSensor::colour_gain::X16)
+#define GESTURE_COL_GAIN_X64        (EVNGestureSensor::colour_gain::X64)
+
+#define GESTURE_GAIN_X1             (EVNGestureSensor::gesture_gain::X1)
+#define GESTURE_GAIN_X2             (EVNGestureSensor::gesture_gain::X2)
+#define GESTURE_GAIN_X4             (EVNGestureSensor::gesture_gain::X4)
+#define GESTURE_GAIN_X8             (EVNGestureSensor::gesture_gain::X8)
+
+#define GESTURE_PROX_GAIN_X1        (EVNGestureSensor::prox_gain::X1)
+#define GESTURE_PROX_GAIN_X2        (EVNGestureSensor::prox_gain::X2)
+#define GESTURE_PROX_GAIN_X4        (EVNGestureSensor::prox_gain::X4)
+#define GESTURE_PROX_GAIN_X8        (EVNGestureSensor::prox_gain::X8)
+
+#define GESTURE_DIMS_UP_DOWN        (EVNGestureSensor::gesture_dims::UP_DOWN)
+#define GESTURE_DIMS_LEFT_RIGHT     (EVNGestureSensor::gesture_dims::LEFT_RIGHT)
+#define GESTURE_DIMS_ALL            (EVNGestureSensor::gesture_dims::ALL)
+
+#define GESTURE_PULSE_US_4          (EVNGestureSensor::pulse_len::US_4)
+#define GESTURE_PULSE_US_8          (EVNGestureSensor::pulse_len::US_8)
+#define GESTURE_PULSE_US_16         (EVNGestureSensor::pulse_len::US_16)
+#define GESTURE_PULSE_US_32         (EVNGestureSensor::pulse_len::US_32)
+
 class EVNGestureSensor : private EVNI2CDevice {
 public:
     static const uint8_t I2C_ADDR = 0x39;

--- a/src/sensors/EVNIMUSensor.h
+++ b/src/sensors/EVNIMUSensor.h
@@ -11,6 +11,23 @@
 #define AXIS_Y 1
 #define AXIS_Z 2
 
+#define IMU_GYRO_DPS_250    (EVNIMUSensor::gyro_range::DPS_250)
+#define IMU_GYRO_DPS_500    (EVNIMUSensor::gyro_range::DPS_500)
+#define IMU_GYRO_DPS_1000   (EVNIMUSensor::gyro_range::DPS_1000)
+#define IMU_GYRO_DPS_2000   (EVNIMUSensor::gyro_range::DPS_2000)
+
+#define IMU_ACCEL_G_2       (EVNIMUSensor::accel_range::G_2)
+#define IMU_ACCEL_G_4       (EVNIMUSensor::accel_range::G_4)
+#define IMU_ACCEL_G_8       (EVNIMUSensor::accel_range::G_8)
+#define IMU_ACCEL_G_16      (EVNIMUSensor::accel_range::G_16)
+
+#define IMU_HZ_184          (EVNIMUSensor::data_rate::HZ_184)
+#define IMU_HZ_92           (EVNIMUSensor::data_rate::HZ_92)
+#define IMU_HZ_41           (EVNIMUSensor::data_rate::HZ_41)
+#define IMU_HZ_20           (EVNIMUSensor::data_rate::HZ_20)
+#define IMU_HZ_10           (EVNIMUSensor::data_rate::HZ_10)
+#define IMU_HZ_5            (EVNIMUSensor::data_rate::HZ_5)
+
 class EVNIMUSensor : private EVNI2CDevice {
 public:
     static const uint8_t I2C_ADDR = 0x68;
@@ -93,6 +110,9 @@ public:
     //TODO: MAYBE explore low power mode and sample rate dividers
 
     EVNIMUSensor(uint8_t port,
+        data_rate data_rate = data_rate::HZ_92,
+        accel_range accel_range = accel_range::G_4,
+        gyro_range gyro_range = gyro_range::DPS_500,
         float gx_offset = 0, float gy_offset = 0, float gz_offset = 0,
         float ax_low = 0, float ax_high = 0, float ay_low = 0,
         float ay_high = 0, float az_low = 0, float az_high = 0)
@@ -100,6 +120,10 @@ public:
     {
         _addr = I2C_ADDR;
         _filter = new Madgwick;
+
+        _data_rate = data_rate;
+        _accel_range = accel_range;
+        _gyro_range = gyro_range;
 
         setCalibrationGyro(gx_offset, gy_offset, gz_offset);
         setCalibrationAccel(ax_low, ax_high, ay_low, ay_high, az_low, az_high);
@@ -120,9 +144,9 @@ public:
 
         _sensor_started = true;
 
-        setAccelRange(accel_range::G_4);
-        setGyroRange(gyro_range::DPS_500);
-        setDataRate(data_rate::HZ_92);
+        setAccelRange(_accel_range);
+        setGyroRange(_gyro_range);
+        setDataRate(_data_rate);
 
         if (calibrate_gyro)
         {
@@ -154,7 +178,9 @@ public:
 
     void setAccelRange(accel_range range)
     {
-        switch (range)
+        _accel_range = range;
+
+        switch (_accel_range)
         {
         case accel_range::G_2:
             _accel_sens = 16384;
@@ -178,7 +204,9 @@ public:
 
     void setGyroRange(gyro_range range)
     {
-        switch (range)
+        _gyro_range = range;
+
+        switch (_gyro_range)
         {
         case gyro_range::DPS_250:
             _gyro_sens = 131;
@@ -202,7 +230,9 @@ public:
 
     void setDataRate(data_rate data_rate)
     {
-        switch (data_rate)
+        _data_rate = data_rate;
+
+        switch (_data_rate)
         {
         case data_rate::HZ_5:
             _measurement_time_us = 200000;
@@ -578,6 +608,10 @@ private:
 
     float _ax_scale, _ay_scale, _az_scale,
         _ax_offset, _ay_offset, _az_offset;
+
+    data_rate _data_rate;
+    accel_range _accel_range;
+    gyro_range _gyro_range;
 
     Madgwick* _filter;
     EVNCompassSensor* _compass;

--- a/src/sensors/EVNIMUSensor.h
+++ b/src/sensors/EVNIMUSensor.h
@@ -110,9 +110,9 @@ public:
     //TODO: MAYBE explore low power mode and sample rate dividers
 
     EVNIMUSensor(uint8_t port,
-        data_rate data_rate = data_rate::HZ_92,
-        accel_range accel_range = accel_range::G_4,
-        gyro_range gyro_range = gyro_range::DPS_500,
+        data_rate data_rate = IMU_HZ_92,
+        accel_range accel_range = IMU_ACCEL_G_4,
+        gyro_range gyro_range = IMU_GYRO_DPS_500,
         float gx_offset = 0, float gy_offset = 0, float gz_offset = 0,
         float ax_low = 0, float ax_high = 0, float ay_low = 0,
         float ay_high = 0, float az_low = 0, float az_high = 0)


### PR DESCRIPTION
1.2.0 (08/12/24)

In this update, we've made several changes (some of them breaking) to the sensor classes in the hopes of making them more approachable for end-users, despite the many sensor settings options made available for them. Additionally, this update fixes urgent bugs for EVNDrivebase (on the latest versions of the Arduino-Pico core) and EVNContinuousServo.

Currently, we're working on obtaining better PID tunings for EVNMotor and EVNDrivebase for better line-tracking performance. Expect that sometime soon :)

-- Features --

EVNColourSensor, EVNCompassSensor, EVNGestureSensor, EVNIMUSensor, EVNEnvSensor:

For these classes, we adopted the convention of using enums in the class as inputs to set sensor settings (e.g. EVNColourSensor::gain::X4). Given the sheer number of settings, the lengthy wording and possible confusion of using enums, we have decided to add #defines that abbreviate the enums into shorter, simpler terms for the user to pass as input.

For instance, for EVNColourSensor, instead of calling sensor.setGain(EVNColourSensor::gain::X1), the user may now sensor.setGain(COLOUR_GAIN_X1), which is shorter and less confusing.

These additions will not break existing code; the #defines will get converted to the enums during compilation. However, there are some changes or removals of certain enums that will break existing code, detailed more closely below.

-- Changes --

EVNMotor: The behaviour of runAngle() when given negative inputs has been standardised and clarified in docs
EVNDrivebase: The behaviour of curve(), curveTurnRate() and straight() when given negative inputs has been standardised and clarified in docs
EVNIMUSensor: Constructor now contains 3 additional input parameters for sensor settings
EVNEnvSensor: Constructor now contains 5 additional input parameters for sensor settings (docs were previously outdated)

-- BREAKING Changes --
EVNCompassSensor: hmc_samples and qmc_samples enums have been renamed to hmc_sampling and qmc_sampling. This will break existing code that sets the sensor sampling rate, and should be changed to use the newly added #defines.
EVNCompassSensor: setSamplesQMC() and setSamplesHMC() renamed to setSamplingRateQMC() and setSamplingRateHMC() respectively
EVNCompassSensor: setModeQMC() and setModeHMC() combined into one function setMode()

EVNCompassSensor, EVNEnvSensor: setMode() now receives a boolean (instead of enum) indicating whether to enable/disable measurement. This will break existing code that sets sensor mode, and should be changed to use booleans instead.

-- Bugfixes --

EVNDrivebase: Fixed bug for Arduino-Pico >=4.3.0 where begin() would crash
EVNContinuousServo: Fixed compilation errors
