### PR TITLE
Version 1.2.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,18 @@
+1.2.2 (20/12/24)
+
+-- Features --
+
+EVNDrivebase: Even after drivebase is instantiated, EVNMotor functions can now be called on the drivebase motors! Doing so while EVNDrivebase commands are running will automatically brake the drivebase, before carrying out the given EVNotor command. Likewise, calling EVNDrivebase commands while an EVNMotor command is running will brake the drivebase before performing the command.
+
+-- Bugfixes --
+
+EVNDrivebase: Fixed bug where drivebase seems to be unresponsive at low turning rates (particularly evident when running drivePct() with sub-1% turning rate)
+
+-- Breaking Changes --
+
+EVNMotor: setMode() function removed
+EVNDrivebase: setMode() function removed
+
 1.2.1 (18/12/24)
 
 More breaking changes...we'll try to keep them to a minimum in the future.

--- a/docs/actuators/evndrivebase.rst
+++ b/docs/actuators/evndrivebase.rst
@@ -354,12 +354,6 @@ Control Settings
 
 To view the default PD and accel/decel values, look at ``src\evn_motor_defs.h`` in the Github repository.
 
-.. function:: void setMode(bool enable)
-
-    Disables any movement functions called afterwards. Does not disable odometry or wipe settings.
-
-    :param enable: Whether drivebase movement should be enabled
-
 .. function:: void setSpeedKp(float kp);
 
     Sets proportional gain values for the speed controller (controls average drivebase speed).

--- a/docs/actuators/evnmotor.rst
+++ b/docs/actuators/evnmotor.rst
@@ -267,12 +267,6 @@ Control Settings
 
 To view the default PD and accel/decel values, look at ``src\evn_motor_defs.h`` in the Github repository.
 
-.. function:: void setMode(bool enable)
-
-    Disables any movement functions called afterwards. Does not disable odometry or wipe settings.
-
-    :param enable: Whether drivebase movement should be enabled
-
 .. function:: void setKp(float kp)
 
     Sets proportional gain values for the PD controller (controls rotational/angular velocity of motor shaft).

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EVN
-version=1.2.1
+version=1.2.2
 author=Heng Teng Yi <tengyi.maker@gmail.com>
 maintainer=Heng Teng Yi <tengyi.maker@gmail.com>
 sentence=Software libraries for EVN Alpha.


### PR DESCRIPTION
1.2.2 (20/12/24)

-- Features --

EVNDrivebase: Even after drivebase is instantiated, EVNMotor functions can now be called on the drivebase motors! Doing so while EVNDrivebase commands are running will automatically brake the drivebase, before carrying out the given EVNotor command. Likewise, calling EVNDrivebase commands while an EVNMotor command is running will brake the drivebase before performing the command.

-- Bugfixes --

EVNDrivebase: Fixed bug where drivebase seems to be unresponsive at low turning rates (particularly evident when running drivePct() with sub-1% turning rate)

-- Breaking Changes --

EVNMotor: setMode() function removed
EVNDrivebase: setMode() function removed