### PR TITLE
Version 1.3.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.3.1 (13/1/25)
+
+-- Bugfixes(?) --
+
+EVNMotor, EVNDrivebase: Re-engineered fix for previous bug where begin() failed to execute properly, since begin() still seems to fail occasionally in a hard-to-recreate manner. If this issue is still present, we'll continue investigating.
+
 1.3.0 (3/1/25)
 
 Happy new year!

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EVN
-version=1.3.0
+version=1.3.1
 author=Heng Teng Yi <tengyi.maker@gmail.com>
 maintainer=Heng Teng Yi <tengyi.maker@gmail.com>
 sentence=Software libraries for EVN Alpha.

--- a/src/EVNAlpha.cpp
+++ b/src/EVNAlpha.cpp
@@ -21,6 +21,8 @@ EVNAlpha::EVNAlpha(uint8_t mode, bool link_led, bool link_movement, bool button_
 
 void EVNAlpha::begin()
 {
+    rp2040.idleOtherCore();
+
     //set correct I2C and Serial pins
 #if (defined(ARDUINO_GENERIC_RP2040))
     Wire1.setSDA(PIN_WIRE1_SDA);
@@ -48,7 +50,7 @@ void EVNAlpha::begin()
     //initialize battery ADC if available
     if (this->beginADC()) _battery_adc_started = true;
 
-    ports.setPort(1);
+    rp2040.resumeOtherCore();
 }
 
 void EVNAlpha::printPorts()

--- a/src/actuators/EVNMotor.cpp
+++ b/src/actuators/EVNMotor.cpp
@@ -116,12 +116,9 @@ EVNMotor::EVNMotor(uint8_t port, uint8_t motor_type, uint8_t motor_dir, uint8_t 
 
 void EVNMotor::begin() volatile
 {
-	EVNCoreSync0.begin();
+	rp2040.idleOtherCore();
 
-	if (timerisr_enabled)
-		EVNCoreSync0.core0_enter();
-	else
-		EVNCoreSync0.core0_enter_force();
+	EVNCoreSync0.begin();
 
 	//configure pins
 	analogWriteFreq(PWM_FREQ);
@@ -134,7 +131,7 @@ void EVNMotor::begin() volatile
 	//attach pin change interrupts (encoder) and timer interrupt (PID control)
 	attach_interrupts(&_encoder, &_pid_control);
 
-	EVNCoreSync0.core0_exit();
+	rp2040.resumeOtherCore();
 }
 
 void EVNMotor::setKp(float kp) volatile
@@ -654,15 +651,12 @@ EVNDrivebase::EVNDrivebase(float wheel_dia, float axle_track, EVNMotor* motor_le
 
 void EVNDrivebase::begin() volatile
 {
-	EVNCoreSync0.begin();
-	if (timerisr_enabled || EVNMotor::timerisr_enabled)
-		EVNCoreSync0.core0_enter();
-	else
-		EVNCoreSync0.core0_enter_force();
+	rp2040.idleOtherCore();
 
+	EVNCoreSync0.begin();
 	attach_interrupts(&db);
 
-	EVNCoreSync0.core0_exit();
+	rp2040.resumeOtherCore();
 }
 
 void EVNDrivebase::setSpeedKp(float kp) volatile

--- a/src/actuators/EVNServo.cpp
+++ b/src/actuators/EVNServo.cpp
@@ -34,6 +34,7 @@ EVNServoBase::EVNServoBase(uint8_t port, bool servo_dir, uint16_t min_pulse_us, 
 
 void EVNServoBase::begin() volatile
 {
+    EVNCoreSync1.begin();
     _servo.servo->attach(_servo.pin, 200, 2800);
 }
 
@@ -52,6 +53,8 @@ EVNServo::EVNServo(uint8_t port, bool servo_dir, uint16_t range, float start_pos
 
 void EVNServo::begin() volatile
 {
+    rp2040.idleOtherCore();
+
     EVNServoBase::begin();
     attach_interrupts(&_servo);
 
@@ -62,6 +65,8 @@ void EVNServo::begin() volatile
         pulse = (float)_servo.max_pulse_us - pulse;
 
     this->writeMicroseconds(pulse);
+
+    rp2040.resumeOtherCore();
 }
 
 void EVNServo::write(float position, uint16_t wait_time_ms, float dps) volatile
@@ -136,11 +141,15 @@ void EVNServo::setMode(bool enable) volatile
 
 void EVNContinuousServo::begin() volatile
 {
+    rp2040.idleOtherCore();
+
     EVNServoBase::begin();
     attach_interrupts(&_servo);
 
     float pulse = (float)(_servo.max_pulse_us - _servo.min_pulse_us) / 2 + _servo.min_pulse_us;
     this->writeMicroseconds(pulse);
+
+    rp2040.resumeOtherCore();
 }
 
 void EVNContinuousServo::write(float duty_cycle_pct) volatile

--- a/src/actuators/EVNServo.h
+++ b/src/actuators/EVNServo.h
@@ -72,8 +72,6 @@ private:
 
             if (!timerisr_enabled)
             {
-                EVNCoreSync1.begin();
-
                 if (rp2040.cpuid() == 0)
                     alarm_pool_add_repeating_timer_us(EVNISRTimer0.sharedAlarmPool(), TIMER_INTERVAL_US, timerisr, nullptr, &EVNISRTimer0.sharedISRTimer(0));
                 else
@@ -178,8 +176,6 @@ private:
                     cancel_repeating_timer(&EVNISRTimer0.sharedISRTimer(0));
                     cancel_repeating_timer(&EVNISRTimer1.sharedISRTimer(0));
                 }
-
-                EVNCoreSync1.begin();
 
                 if (rp2040.cpuid() == 0)
                     alarm_pool_add_repeating_timer_us(EVNISRTimer0.sharedAlarmPool(), TIMER_INTERVAL_US, timerisr, nullptr, &EVNISRTimer0.sharedISRTimer(1));

--- a/src/helper/EVNCoreSync.h
+++ b/src/helper/EVNCoreSync.h
@@ -13,7 +13,7 @@ public:
     {
         _spin_timeout_us = spin_timeout_us;
         _stall_time_us = stall_time_us;
-    };
+    }
 
     void begin()
     {
@@ -24,7 +24,7 @@ public:
             _core = rp2040.cpuid();
             _started = true;
         }
-    };
+    }
 
     void core0_ensure_core1_isr_can_execute()
     {
@@ -44,8 +44,7 @@ public:
         // if pin ISRs are using mutex, 2nd spin lock is used
         else if (!is_spin_locked(_lock))
             stall();
-
-    };
+    }
 
     void core0_enter()
     {
@@ -53,16 +52,7 @@ public:
 
         core0_ensure_core1_isr_can_execute();
         mutex_enter_blocking(&_mutex);
-    };
-
-    void core0_enter_force()
-    {
-        //grabs mutex without ensuring timerisr has executed once
-
-        if (!_started) return;
-
-        mutex_enter_blocking(&_mutex);
-    };
+    }
 
     void core0_exit()
     {
@@ -71,7 +61,7 @@ public:
         if (!_started) return;
 
         mutex_exit(&_mutex);
-    };
+    }
 
     bool core1_timer_isr_enter()
     {
@@ -83,7 +73,7 @@ public:
             spin_lock_unsafe_blocking(_lock);
 
         return _timer_isr_acquired;
-    };
+    }
 
     void core1_timer_isr_exit()
     {
@@ -98,7 +88,7 @@ public:
             spin_unlock_unsafe(_lock);
             mutex_exit(&_mutex);
         }
-    };
+    }
 
     bool core1_pin_isr_enter()
     {
@@ -113,7 +103,7 @@ public:
             _pin_isr_acquired = mutex_try_enter_block_until(&_mutex, delayed_by_us(get_absolute_time(), _spin_timeout_us));
 
         return (_pin_isr_acquired || owner == _core);
-    };
+    }
 
     void core1_pin_isr_exit()
     {
@@ -125,7 +115,7 @@ public:
             _pin_isr_acquired = false;
             mutex_exit(&_mutex);
         }
-    };
+    }
 
 private:
 


### PR DESCRIPTION
1.3.1 (13/1/25)

-- Bugfixes(?) --

EVNMotor, EVNDrivebase: Re-engineered fix for previous bug where begin() failed to execute properly, since begin() still seems to fail occasionally in a hard-to-recreate manner. If this issue is still present, we'll continue investigating.