### PR TITLE
Version 1.3.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+1.3.5 (7/5/25)
+
+-- Bugfixes --
+EVNDrivebase: Fix bug where hold() moves to incorrect setpoint when called immediately after calling individual EVNMotor functions on the drivebase motors.
+
 1.3.4 (11/3/25)
 
 -- Bugfixes --

--- a/docs/getting-started/hardware-overview.rst
+++ b/docs/getting-started/hardware-overview.rst
@@ -188,7 +188,7 @@ However, the remaining output-capable pins (GP0-3 and 8-9) are connected to othe
 
 Timers
 """"""
-The ``EVNAlpha``, ``EVNMotor``and ``EVNServo`` libraries use hardware timers 1 and 2 to automatically update control loops for the motors and servos, without any end-user code.
+The ``EVNAlpha``, ``EVNMotor`` and ``EVNServo`` libraries use hardware timers 1 and 2 to automatically update control loops for the motors and servos, without any end-user code.
 
 This leaves hardware timers 0 and 3 completely free for the end user. Users may also be able to share timers 1 and 2 with our libraries, as they are not fully utilised.
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EVN
-version=1.3.4
+version=1.3.5
 author=Heng Teng Yi <tengyi.maker@gmail.com>
 maintainer=Heng Teng Yi <tengyi.maker@gmail.com>
 sentence=Software libraries for EVN Alpha.

--- a/src/actuators/EVNMotor.cpp
+++ b/src/actuators/EVNMotor.cpp
@@ -453,7 +453,6 @@ void EVNMotor::runSpeed(float dps) volatile
 {
 	if (!timerisr_enabled) return;
 	EVNCoreSync0.core0_enter();
-	disable_connected_drivebase_unsafe();
 
 	runSpeed_unsafe(dps);
 
@@ -462,6 +461,8 @@ void EVNMotor::runSpeed(float dps) volatile
 
 void EVNMotor::runSpeed_unsafe(float dps) volatile
 {
+	disable_connected_drivebase_unsafe();
+
 	_pid_control.target_dps = clean_input_dps_unsafe(dps);
 	_pid_control.run_dir = clean_input_dir(dps);
 
@@ -1306,12 +1307,10 @@ void EVNDrivebase::stop() volatile
 	EVNCoreSync0.core0_enter();
 
 	set_mode_unsafe(db.id, true);
-
 	db.stop_action = STOP_BRAKE;
 	stopAction_static(&db);
 
 	EVNCoreSync0.core0_exit();
-
 	stall_until_stopped();
 }
 
@@ -1321,12 +1320,10 @@ void EVNDrivebase::coast() volatile
 	EVNCoreSync0.core0_enter();
 
 	set_mode_unsafe(db.id, true);
-
 	db.stop_action = STOP_COAST;
 	stopAction_static(&db);
 
 	EVNCoreSync0.core0_exit();
-
 	stall_until_stopped();
 }
 
@@ -1335,13 +1332,10 @@ void EVNDrivebase::hold() volatile
 	if (!timerisr_enabled) return;
 	EVNCoreSync0.core0_enter();
 
-	set_mode_unsafe(db.id, true);
-
 	db.stop_action = STOP_HOLD;
 	stopAction_static(&db);
 
 	EVNCoreSync0.core0_exit();
-
 	stall_until_stopped();
 }
 

--- a/src/helper/EVNPortSelector.cpp
+++ b/src/helper/EVNPortSelector.cpp
@@ -15,17 +15,29 @@ void EVNPortSelector::begin()
 		Wire.setClock(_i2c_freq);
 		Wire1.setClock(_i2c_freq);
 
-		Wire1.beginTransmission(I2C_ADDR);
-		Wire1.write(1 << 0);
-		Wire1.endTransmission();
-		_wire1_port = 9;
-		_wire1_time_ms = millis();
+		delay(50);
 
 		Wire.beginTransmission(I2C_ADDR);
-		Wire.write(1 << 0);
+		Wire.write(0);
+		Wire.endTransmission();
+		
+		Wire1.beginTransmission(I2C_ADDR);
+		Wire1.write(0);
+		Wire1.endTransmission();
+		
+		delay(50);
+
+		Wire.beginTransmission(I2C_ADDR);
+		Wire.write(1);
 		Wire.endTransmission();
 		_wire0_port = 1;
 		_wire0_time_ms = millis();
+
+		Wire1.beginTransmission(I2C_ADDR);
+		Wire1.write(1);
+		Wire1.endTransmission();
+		_wire1_port = 9;
+		_wire1_time_ms = millis();
 
 		_started = true;
 	}


### PR DESCRIPTION
1.3.5 (7/5/25)

-- Bugfixes --
EVNDrivebase: Fix bug where hold() moves to incorrect setpoint when called immediately after calling individual EVNMotor functions on the drivebase motors.
