### PR TITLE
Version 1.4.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+1.4.5 (12/10/25)
+
+More quick fixes!
+
+-- Bugfixes --
+
+EVNColourSensor: Fix broken COLOUR_GAIN_X60 preprocessor macro
+
+Docs: Fix broken links to peripheral docs in Standard Peripherals page
+
+EVNRGBLED: Improved timings on the LEDs' PIO controller, which might be the cause of some reported glitches, so it should be more stable now.
+
+-- Changes --
+
 1.4.4 (14/8/25)
 
 Small quick bugfix update

--- a/docs/getting-started/standard-peripherals.rst
+++ b/docs/getting-started/standard-peripherals.rst
@@ -194,18 +194,18 @@ List of Standard Peripherals
 .. |contservo.JPG| image:: ../images/standard-peripherals/contservo.JPG
 
 
-.. _EVNColourSensor: ../sensors/EVNColourSensor.html
-.. _EVNDistanceSensor: ../sensors/EVNDistanceSensor.html
-.. _EVNCompassSensor: ../sensors/EVNCompassSensor.html
-.. _EVNIMUSensor: ../sensors/EVNIMUSensor.html
-.. _EVNGestureSensor: ../sensors/EVNGestureSensor.html
-.. _EVNEnvSensor: ../sensors/EVNEnvSensor.html
-.. _EVNTouchArray: ../sensors/EVNTouchArray.html
-.. _EVNDisplay: ../displays/EVNDisplay.html
-.. _EVNMatrixLED: ../displays/EVNMatrixLED.html
-.. _EVNSevenSegmentLED: ../displays/EVNSevenSegmentLED.html
-.. _EVNRGBLED: ../displays/EVNRGBLED.html
-.. _EVNServo: ../actuators/EVNServo.html
-.. _EVNContinuousServo: ../actuators/EVNContinuousServo.html
-.. _EVNAnalogMux: ../others/EVNAnalogMux.html
-.. _EVNBluetooth: ../others/EVNBluetooth.html
+.. _EVNColourSensor: ../sensors/evncoloursensor.html
+.. _EVNDistanceSensor: ../sensors/evndistancesensor.html
+.. _EVNCompassSensor: ../sensors/evncompasssensor.html
+.. _EVNIMUSensor: ../sensors/evnimusensor.html
+.. _EVNGestureSensor: ../sensors/evngesturesensor.html
+.. _EVNEnvSensor: ../sensors/evnenvsensor.html
+.. _EVNTouchArray: ../sensors/evntoucharray.html
+.. _EVNDisplay: ../displays/evndisplay.html
+.. _EVNMatrixLED: ../displays/evnmatrixled.html
+.. _EVNSevenSegmentLED: ../displays/evnsevensegmentled.html
+.. _EVNRGBLED: ../displays/evnrgbled.html
+.. _EVNServo: ../actuators/evnservo.html
+.. _EVNContinuousServo: ../actuators/evncontinuousservo.html
+.. _EVNAnalogMux: ../others/evnadc.html
+.. _EVNBluetooth: ../others/evnbluetooth.html

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EVN
-version=1.4.4
+version=1.4.5
 author=Heng Teng Yi <tengyi.maker@gmail.com>
 maintainer=Heng Teng Yi <tengyi.maker@gmail.com>
 sentence=Software libraries for EVN Alpha.

--- a/src/displays/EVNRGBLED.h
+++ b/src/displays/EVNRGBLED.h
@@ -11,7 +11,7 @@ static PIOProgram _rgbLedPgm(&ws2812_program);
 class EVNRGBLED
 {
 public:
-    const static uint16_t RESET_TIME_US = 310;
+    const static uint16_t RESET_TIME_US = 340;
     const static uint8_t MAX_OBJECTS = 4;
 
     EVNRGBLED(uint8_t port, uint8_t led_count = 8, bool invert = false)

--- a/src/displays/ws2812/ws2812.pio
+++ b/src/displays/ws2812/ws2812.pio
@@ -7,9 +7,9 @@
 .program ws2812
 .side_set 1
 
-.define public T1 8
-.define public T2 9
-.define public T3 8
+.define public T1 3
+.define public T2 3
+.define public T3 4
 
 .lang_opt python sideset_init = pico.PIO.OUT_HIGH
 .lang_opt python out_init     = pico.PIO.OUT_HIGH

--- a/src/displays/ws2812/ws2812.pio.h
+++ b/src/displays/ws2812/ws2812.pio.h
@@ -15,17 +15,17 @@
 #define ws2812_wrap_target 0
 #define ws2812_wrap 3
 
-#define ws2812_T1 2
-#define ws2812_T2 5
-#define ws2812_T3 3
+#define ws2812_T1 3
+#define ws2812_T2 3
+#define ws2812_T3 4
 
 static const uint16_t ws2812_program_instructions[] = {
-    //     .wrap_target
-0x6221, //  0: out    x, 1            side 0 [2] 
-0x1123, //  1: jmp    !x, 3           side 1 [1] 
-0x1400, //  2: jmp    0               side 1 [4] 
-0xa442, //  3: nop                    side 0 [4] 
-//     .wrap
+            //     .wrap_target
+    0x6321, //  0: out    x, 1            side 0 [3] 
+    0x1223, //  1: jmp    !x, 3           side 1 [2] 
+    0x1200, //  2: jmp    0               side 1 [2] 
+    0xa242, //  3: nop                    side 0 [2] 
+            //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
@@ -51,59 +51,6 @@ static inline void ws2812_program_init(PIO pio, uint sm, uint offset, uint pin, 
     sm_config_set_out_shift(&c, false, true, rgbw ? 32 : 24);
     sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
     int cycles_per_bit = ws2812_T1 + ws2812_T2 + ws2812_T3;
-    float div = clock_get_hz(clk_sys) / (freq * cycles_per_bit);
-    sm_config_set_clkdiv(&c, div);
-    pio_sm_init(pio, sm, offset, &c);
-    pio_sm_set_enabled(pio, sm, true);
-}
-
-#endif
-
-// --------------- //
-// ws2812_parallel //
-// --------------- //
-
-#define ws2812_parallel_wrap_target 0
-#define ws2812_parallel_wrap 3
-
-#define ws2812_parallel_T1 2
-#define ws2812_parallel_T2 5
-#define ws2812_parallel_T3 3
-
-static const uint16_t ws2812_parallel_program_instructions[] = {
-    //     .wrap_target
-0x6020, //  0: out    x, 32                      
-0xa10b, //  1: mov    pins, !null            [1] 
-0xa401, //  2: mov    pins, x                [4] 
-0xa103, //  3: mov    pins, null             [1] 
-//     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program ws2812_parallel_program = {
-    .instructions = ws2812_parallel_program_instructions,
-    .length = 4,
-    .origin = -1,
-};
-
-static inline pio_sm_config ws2812_parallel_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + ws2812_parallel_wrap_target, offset + ws2812_parallel_wrap);
-    return c;
-}
-
-#include "hardware/clocks.h"
-static inline void ws2812_parallel_program_init(PIO pio, uint sm, uint offset, uint pin_base, uint pin_count, float freq) {
-    for (uint i = pin_base; i < pin_base + pin_count; i++) {
-        pio_gpio_init(pio, i);
-    }
-    pio_sm_set_consecutive_pindirs(pio, sm, pin_base, pin_count, true);
-    pio_sm_config c = ws2812_parallel_program_get_default_config(offset);
-    sm_config_set_out_shift(&c, true, true, 32);
-    sm_config_set_out_pins(&c, pin_base, pin_count);
-    sm_config_set_set_pins(&c, pin_base, pin_count);
-    sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
-    int cycles_per_bit = ws2812_parallel_T1 + ws2812_parallel_T2 + ws2812_parallel_T3;
     float div = clock_get_hz(clk_sys) / (freq * cycles_per_bit);
     sm_config_set_clkdiv(&c, div);
     pio_sm_init(pio, sm, offset, &c);

--- a/src/sensors/EVNColourSensor.h
+++ b/src/sensors/EVNColourSensor.h
@@ -67,7 +67,7 @@ public:
         X1 = 0x00,
         X4 = 0x01,
         X16 = 0x02,
-        X64 = 0x03
+        X60 = 0x03
     };
 
     EVNColourSensor(uint8_t port, uint8_t integration_cycles = 1, gain gain = COLOUR_GAIN_X16) : EVNI2CDevice(port)


### PR DESCRIPTION
1.4.5 (12/10/25)

More quick fixes!

-- Bugfixes --

EVNColourSensor: Fix broken COLOUR_GAIN_X60 preprocessor macro

Docs: Fix broken links to peripheral docs in Standard Peripherals page

EVNRGBLED: Improved timings on the LEDs' PIO controller, which might be the cause of some reported glitches, so it should be more stable now.