### PR TITLE
Version 1.4.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.4.6 (16/8/26)
+
+-- Changes --
+
+EVNMotor, EVNDrivebase: Changed motors to operate in PWM slow decay mode (same as Pybricks, as far as we know).
+
 1.4.5 (12/10/25)
 
 More quick fixes!
@@ -9,8 +15,6 @@ EVNColourSensor: Fix broken COLOUR_GAIN_X60 preprocessor macro
 Docs: Fix broken links to peripheral docs in Standard Peripherals page
 
 EVNRGBLED: Improved timings on the LEDs' PIO controller, which might be the cause of some reported glitches, so it should be more stable now.
-
--- Changes --
 
 1.4.4 (14/8/25)
 

--- a/docs/board/evnalpha.rst
+++ b/docs/board/evnalpha.rst
@@ -24,7 +24,7 @@ EVN Alpha has 2 TCA9548A I2C multiplexers, 1 on each I2C bus. This allows users 
 
 .. note:: For Ports 9-16, 3rd party libraries and end-user code have to use Wire1 to interface with their sensors, as these ports are connected to the I2C1 bus.
 
-.. class:: EVNAlpha(uint8_t mode = BUTTON_TOGGLE, bool link_led = true, bool link_movement = false, bool button_invert = false, uint32_t i2c_freq = 100000)
+.. class:: EVNAlpha(uint8_t mode = BUTTON_TOGGLE, bool link_led = true, bool link_movement = false, bool button_invert = false, uint32_t i2c_freq = 400000)
     
     :param mode: Determines behaviour of ``buttonRead()``. Defaults to ``BUTTON_TOGGLE``
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EVN
-version=1.4.5
+version=1.4.6
 author=Heng Teng Yi <tengyi.maker@gmail.com>
 maintainer=Heng Teng Yi <tengyi.maker@gmail.com>
 sentence=Software libraries for EVN Alpha.

--- a/src/actuators/EVNMotor.h
+++ b/src/actuators/EVNMotor.h
@@ -334,13 +334,13 @@ private:
 		if (EVNAlpha::motorsEnabled()) {
 			if (speedc > 0)
 			{
-				digitalWrite(pidArg->motorb, LOW);
-				analogWrite(pidArg->motora, speedc * PWM_MAX_VAL);
+				analogWrite(pidArg->motorb, (1-speedc) * PWM_MAX_VAL);
+				digitalWrite(pidArg->motora, HIGH);
 			}
 			else
 			{
-				digitalWrite(pidArg->motora, LOW);
-				analogWrite(pidArg->motorb, -speedc * PWM_MAX_VAL);
+				analogWrite(pidArg->motora, (1+speedc) * PWM_MAX_VAL);
+				digitalWrite(pidArg->motorb, HIGH);
 			}
 		}
 	}


### PR DESCRIPTION
1.4.6 (16/8/26)

-- Changes --

EVNMotor, EVNDrivebase: Changed motors to operate in PWM slow decay mode (same as Pybricks, as far as we know).
