### PR TITLE
Version 1.4.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.4.7 (19/8/26)
+
+-- Bugfixes --
+
+EVNAlpha: Modified battery reading functions to be blocking (about 3-4ms to execute). This change was made with an internal change to use the ADC in one-shot measurement mode; our previous usage of continuous conversion mode with a disabled watchdog timer led to very high idle current draw which drained batteries very quickly.
+
 1.4.6 (16/8/26)
 
 -- Changes --

--- a/docs/board/evnalpha.rst
+++ b/docs/board/evnalpha.rst
@@ -150,20 +150,12 @@ These functions will be used mainly if you are trying to operate third-party I2C
 Battery Voltage Reading
 """"""""""""""""""""""""
 All battery voltage reading functions have a ``flash_when_low`` input. 
-This is a low battery alert function, which flashes the LED at a rate of 5Hz (5 blinks per second) when the battery voltage is too low.
+This is for a low battery alert function, which flashes the LED at a rate of 5Hz (5 blinks per second) when the battery voltage is too low.
 
+To add the alert to your code, call any of the functions below and the board will alert if the voltage is below your set threshold.
 When the alert is on, the LED's previous output (whether linked to button or controlled by the user) will be overridden.
-To add the alert to your code, add ``getBatteryVoltage()`` (or ``getCell1Voltage()`` **and** ``getCell2Voltage()``) to ``void loop()`` and they will check the voltage each loop.
 
-.. code-block:: c++
-
-    void loop()
-    {
-      //main code here
-      
-      board.getBatteryVoltage(); //battery alert!
-    }
-
+.. note:: All battery voltage reading functions require 3-4ms to execute (for the ADC to perform a one-shot measurement).
 
 .. function:: int16_t getBatteryVoltage(bool flash_when_low = true, uint16_t low_threshold_mv = 6900)
 
@@ -178,7 +170,7 @@ To add the alert to your code, add ``getBatteryVoltage()`` (or ``getCell1Voltage
         
 .. function:: int16_t getCell1Voltage(bool flash_when_low = true, uint16_t low_threshold_mv = 3450)
 
-    Cell 1 refers to the cell nearer to the edge of the board.
+    Cell 1 refers to the cell nearer to the edge of the board. Circuit-wise, it is the "top" cell where one end is at battery potential.
     
     :param flash_when_low: Sets LED to flash when battery voltage falls below ``low_threshold_mv``. Defaults to ``true``
     :param low_threshold_mv: Cell voltage threshold (in millivolts). When this cell's voltage falls below this threshold and ``flash_when_low`` is ``true``, low battery alert is triggered. Defaults to 3450.
@@ -191,7 +183,7 @@ To add the alert to your code, add ``getBatteryVoltage()`` (or ``getCell1Voltage
 
 .. function:: int16_t getCell2Voltage(bool flash_when_low = true, uint16_t low_threshold_mv = 3450)
 
-    Cell 2 refers to the cell nearer to the centre of the board.
+    Cell 2 refers to the cell nearer to the centre of the board. Circuit-wise, it is the "bottom" cell where one end is at ground potential.
 
     :param flash_when_low: Sets LED to flash when battery voltage falls below ``low_threshold_mv``. Defaults to ``true``
     :param low_threshold_mv: Cell voltage threshold (in millivolts). When this cell's voltage falls below this threshold and ``flash_when_low`` is ``true``, the low battery alert is triggered. Defaults to 3450.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EVN
-version=1.4.6
+version=1.4.7
 author=Heng Teng Yi <tengyi.maker@gmail.com>
 maintainer=Heng Teng Yi <tengyi.maker@gmail.com>
 sentence=Software libraries for EVN Alpha.

--- a/src/EVNAlpha.cpp
+++ b/src/EVNAlpha.cpp
@@ -14,7 +14,7 @@ uint32_t EVNAlpha::_i2c_freq;
 EVNAlpha::EVNAlpha(uint8_t mode, bool link_led, bool link_movement, bool button_invert, uint32_t i2c_freq)
 {
     _started = false;
-    _battery_adc_started = false;
+    _bq_adc_avail = false;
     _mode = constrain(mode, 0, 2);
     _link_led = link_led;
     _link_movement = link_movement;
@@ -50,8 +50,8 @@ void EVNAlpha::begin()
         ports.begin();
         button_led.begin();
 
-        //initialize battery ADC if available
-        if (this->beginADC()) _battery_adc_started = true;
+        //check if battery ADC is available
+        _bq_adc_avail = checkADC();
 
         updateBatteryVoltage();
         _vbatt_on_boot = _vbatt;
@@ -81,43 +81,44 @@ void EVNAlpha::printPorts()
 
 }
 
-bool EVNAlpha::beginADC()
+bool EVNAlpha::checkADC()
 {
     ports.setPort((uint8_t)bq25887::I2C_PORT);
 
     //check for BQ25887 ID
     //NOTE: BQ25887 not in use for our pre-V1.3 users, so this is important
-    uint8_t id = 0;
     Wire1.beginTransmission((uint8_t)bq25887::I2C_ADDR);
     Wire1.write((uint8_t)bq25887::REG_PART_INFO);
     Wire1.endTransmission();
     Wire1.requestFrom((uint8_t)bq25887::I2C_ADDR, (uint8_t)1);
-    id = Wire1.read();
-
-    id = (id & (uint8_t)bq25887::MASK_PART_INFO) >> 3;
+    uint8_t id = (Wire1.read() & (uint8_t)bq25887::MASK_PART_INFO) >> 3;
 
     if (id != (uint8_t)bq25887::ID)
         return false;
 
-    //enable ADCs on BQ25887
+    // enable watchdog, as it may have been disabled by older library versions
+    Wire1.beginTransmission((uint8_t)bq25887::I2C_ADDR);
+    Wire1.write((uint8_t)bq25887::REG_CHG_CONTROL1);
+    Wire1.write((uint8_t)bq25887::CMD_WATCHDOG_ENABLE);
+    Wire1.endTransmission();
+    
+    return true;
+}
+
+void EVNAlpha::startADCOneShot()
+{
     Wire1.beginTransmission((uint8_t)bq25887::I2C_ADDR);
     Wire1.write((uint8_t)bq25887::REG_ADC_CONTROL);
     Wire1.write((uint8_t)bq25887::CMD_ADC_CONTROL_ENABLE);
     Wire1.endTransmission();
-
-    //disable watchdog, or ADC resets after 40s
-    Wire1.beginTransmission((uint8_t)bq25887::I2C_ADDR);
-    Wire1.write((uint8_t)bq25887::REG_CHG_CONTROL1);
-    Wire1.write((uint8_t)bq25887::CMD_WATCHDOG_DISABLE);
-    Wire1.endTransmission();
-
-    return true;
 }
 
 int16_t EVNAlpha::getBatteryVoltage(bool flash_when_low, uint16_t low_threshold_mv)
 {
-    if (_battery_adc_started)
+    if (_bq_adc_avail)
     {
+        startADCOneShot();
+        delay(3);
         updateBatteryVoltage();
 
         if (flash_when_low)
@@ -130,8 +131,10 @@ int16_t EVNAlpha::getBatteryVoltage(bool flash_when_low, uint16_t low_threshold_
 
 int16_t EVNAlpha::getCell1Voltage(bool flash_when_low, uint16_t low_threshold_mv)
 {
-    if (_battery_adc_started)
+    if (_bq_adc_avail)
     {
+        startADCOneShot();
+        delay(3);
         updateCell1Voltage();
 
         if (flash_when_low)
@@ -144,8 +147,10 @@ int16_t EVNAlpha::getCell1Voltage(bool flash_when_low, uint16_t low_threshold_mv
 
 int16_t EVNAlpha::getCell2Voltage(bool flash_when_low, uint16_t low_threshold_mv)
 {
-    if (_battery_adc_started)
+    if (_bq_adc_avail)
     {
+        startADCOneShot();
+        delay(3);
         updateCell2Voltage();
 
         if (flash_when_low)
@@ -156,9 +161,9 @@ int16_t EVNAlpha::getCell2Voltage(bool flash_when_low, uint16_t low_threshold_mv
     return 0;
 }
 
-void EVNAlpha::updateBatteryVoltage() { if (_battery_adc_started)_vbatt = readADC16((uint8_t)bq25887::REG_VBAT_ADC1); }
-void EVNAlpha::updateCell1Voltage() { if (_battery_adc_started) _vcell1 = readADC16((uint8_t)bq25887::REG_VCELLTOP_ADC1); }
-void EVNAlpha::updateCell2Voltage() { if (_battery_adc_started) _vcell2 = readADC16((uint8_t)bq25887::REG_VCELLBOT_ADC1); }
+void EVNAlpha::updateBatteryVoltage() { if (_bq_adc_avail)_vbatt = readADC16((uint8_t)bq25887::REG_VBAT_ADC1); }
+void EVNAlpha::updateCell1Voltage() { if (_bq_adc_avail) _vcell1 = readADC16((uint8_t)bq25887::REG_VCELLTOP_ADC1); }
+void EVNAlpha::updateCell2Voltage() { if (_bq_adc_avail) _vcell2 = readADC16((uint8_t)bq25887::REG_VCELLBOT_ADC1); }
 
 uint16_t EVNAlpha::readADC16(uint8_t reg)
 {

--- a/src/EVNAlpha.h
+++ b/src/EVNAlpha.h
@@ -22,8 +22,8 @@ private:
         REG_VCELLTOP_ADC1 = 0x1F,
         REG_PART_INFO = 0x25,
         REG_VCELLBOT_ADC1 = 0x26,
-        CMD_ADC_CONTROL_ENABLE = 0b10110000,
-        CMD_WATCHDOG_DISABLE = 0b10001101,
+        CMD_ADC_CONTROL_ENABLE = 0b11110000,
+        CMD_WATCHDOG_ENABLE = 0b10011101,
         MASK_PART_INFO = 0b01111000,
     };
 
@@ -75,14 +75,16 @@ public:
     static EVNButtonLED& sharedButtonLED() { return button_led; }
 
 private:
-    bool beginADC();
+    bool checkADC();
+    void startADCOneShot();
     uint16_t readADC16(uint8_t reg);
     void updateBatteryVoltage();
     void updateCell1Voltage();
     void updateCell2Voltage();
     static int16_t getBatteryVoltageOnBoot_unsafe() { return _vbatt_on_boot; };
+    
 
-    bool _battery_adc_started;
+    bool _bq_adc_avail;
     int16_t _vbatt = 0, _vcell1 = 0, _vcell2 = 0;
 
     static mutex_t _mutex;


### PR DESCRIPTION
1.4.7 (19/8/26)

-- Bugfixes --

EVNAlpha: Modified battery reading functions to be blocking (about 3-4ms to execute). This change was made with an internal change to use the ADC in one-shot measurement mode; our previous usage of continuous conversion mode with a disabled watchdog timer led to very high idle current draw which drained batteries very quickly.
